### PR TITLE
feat(design): personalize generated product surfaces

### DIFF
--- a/.agents/execution/decisions.json
+++ b/.agents/execution/decisions.json
@@ -26,6 +26,12 @@
       "decision": "The self-contained Vibes derivative is composed from a stable golden baseline plus explicit marketing, sample-domain, and Stripe Connect overlays; presentation-only onboarding and admin examples are not promoted to production modules.",
       "status": "active",
       "issue": 95
+    },
+    {
+      "id": "LV-D-006",
+      "decision": "Generated identity and design choices are exposed through one typed product contract and consumed only by metadata, brand, semantic token, density, and navigation-shell surfaces.",
+      "status": "active",
+      "issue": 96
     }
   ]
 }

--- a/.agents/execution/handoff.json
+++ b/.agents/execution/handoff.json
@@ -4,7 +4,7 @@
   "currentOutcome": "LV-105 product identity and semantic design personalization implemented on feature/96-design-personalization.",
   "activeIssue": 96,
   "activeBranch": "feature/96-design-personalization",
-  "activePullRequest": null,
+  "activePullRequest": "https://github.com/DigitalHerencia/LoadedVibes/pull/106",
   "lastCompletedIssue": 95,
   "lastMergedPullRequest": "https://github.com/DigitalHerencia/LoadedVibes/pull/105",
   "nextAction": "Open and review the Issue #96 pull request, then merge when its acceptance criteria remain satisfied.",

--- a/.agents/execution/handoff.json
+++ b/.agents/execution/handoff.json
@@ -1,20 +1,19 @@
 {
   "schemaVersion": 2,
   "status": "in-progress",
-  "currentOutcome": "LV-104 Vibes-derived golden template composition and supported capability modules implemented on feature/95-vibes-template-modules.",
-  "activeIssue": 95,
-  "activeBranch": "feature/95-vibes-template-modules",
-  "activePullRequest": "https://github.com/DigitalHerencia/LoadedVibes/pull/105",
-  "lastCompletedIssue": 94,
-  "lastMergedPullRequest": "https://github.com/DigitalHerencia/LoadedVibes/pull/104",
-  "nextAction": "Open and review the Issue #95 pull request, then merge when its acceptance criteria remain satisfied.",
+  "currentOutcome": "LV-105 product identity and semantic design personalization implemented on feature/96-design-personalization.",
+  "activeIssue": 96,
+  "activeBranch": "feature/96-design-personalization",
+  "activePullRequest": null,
+  "lastCompletedIssue": 95,
+  "lastMergedPullRequest": "https://github.com/DigitalHerencia/LoadedVibes/pull/105",
+  "nextAction": "Open and review the Issue #96 pull request, then merge when its acceptance criteria remain satisfied.",
   "executedEvidence": [
-    "Vibes source revision verified as 19e20084a8c69cc5a70f8db5f8e5d908a84d582f",
-    "corepack pnpm exec vitest run tests/integration/materialize.test.ts (4 tests passed)",
+    "corepack pnpm exec vitest run tests/integration/materialize.test.ts (5 tests passed)",
     "corepack pnpm typecheck",
     "corepack pnpm lint",
     "corepack pnpm format:check",
-    "corepack pnpm pack:check (345 safe entries)"
+    "corepack pnpm test:generated (5 tests passed)"
   ],
   "blockedEvidence": [],
   "notes": [

--- a/.agents/execution/progress.json
+++ b/.agents/execution/progress.json
@@ -83,7 +83,7 @@
       "issue": 96,
       "status": "implemented",
       "branch": "feature/96-design-personalization",
-      "pullRequest": null,
+      "pullRequest": "https://github.com/DigitalHerencia/LoadedVibes/pull/106",
       "evidence": {
         "executed": [
           "corepack pnpm exec vitest run tests/integration/materialize.test.ts (5 tests passed)",

--- a/.agents/execution/progress.json
+++ b/.agents/execution/progress.json
@@ -2,9 +2,9 @@
   "schemaVersion": 2,
   "roadmap": "generator-product-roadmap",
   "status": "in_progress",
-  "activeIssue": 95,
-  "activeBranch": "feature/95-vibes-template-modules",
-  "completed": [92, 93, 94],
+  "activeIssue": 96,
+  "activeBranch": "feature/96-design-personalization",
+  "completed": [92, 93, 94, 95],
   "workItems": [
     {
       "id": "LV-101",
@@ -63,7 +63,7 @@
     {
       "id": "LV-104",
       "issue": 95,
-      "status": "implemented",
+      "status": "verified",
       "branch": "feature/95-vibes-template-modules",
       "pullRequest": "https://github.com/DigitalHerencia/LoadedVibes/pull/105",
       "evidence": {
@@ -74,6 +74,23 @@
           "corepack pnpm lint",
           "corepack pnpm format:check",
           "corepack pnpm pack:check (345 safe entries)"
+        ],
+        "blocked": []
+      }
+    },
+    {
+      "id": "LV-105",
+      "issue": 96,
+      "status": "implemented",
+      "branch": "feature/96-design-personalization",
+      "pullRequest": null,
+      "evidence": {
+        "executed": [
+          "corepack pnpm exec vitest run tests/integration/materialize.test.ts (5 tests passed)",
+          "corepack pnpm typecheck",
+          "corepack pnpm lint",
+          "corepack pnpm format:check",
+          "corepack pnpm test:generated (5 tests passed)"
         ],
         "blocked": []
       }

--- a/packages/core/src/generator/transforms.ts
+++ b/packages/core/src/generator/transforms.ts
@@ -40,7 +40,32 @@ export async function applyTransforms(plan: GenerationPlan): Promise<void> {
     path.join(plan.stagingDirectory, 'loadedvibes.json'),
     `${JSON.stringify(plan.config.recipe, null, 2)}\n`,
   );
-  const capabilitiesSource = `export const loadedVibesCapabilities = ${JSON.stringify(
+  const capabilitiesSource = `export const loadedVibesProduct = ${JSON.stringify(
+    {
+      name: plan.config.recipe.identity.displayName,
+      description:
+        plan.config.recipe.identity.description ||
+        'A focused SaaS product built with Loaded Vibes.',
+    },
+    null,
+    2,
+  )} as const
+
+export type LoadedVibesDesign = {
+  theme: "obsidian" | "paper" | "electric"
+  radius: "compact" | "medium" | "rounded"
+  density: "compact" | "comfortable"
+  navigation: "sidebar" | "topbar"
+  mode: "light" | "dark" | "system"
+}
+
+export const loadedVibesDesign: LoadedVibesDesign = ${JSON.stringify(
+    plan.config.recipe.design,
+    null,
+    2,
+  )}
+
+export const loadedVibesCapabilities = ${JSON.stringify(
     {
       marketing: plan.config.recipe.modules.marketing,
       sampleDomain: plan.config.recipe.modules.sampleDomain !== false,

--- a/templates/golden/app/globals.css
+++ b/templates/golden/app/globals.css
@@ -30,7 +30,8 @@
 @plugin "@tailwindcss/typography";
 
 :root {
-  --radius: 0rem;
+  --radius: 0.5rem;
+  --shell-padding-y: 2rem;
 
   --neutral-950: oklch(5.5% 0 0);
   --neutral-900: oklch(10.5% 0 0);
@@ -64,11 +65,111 @@
   --ring: var(--blue-600);
 }
 
+[data-theme="paper"] {
+  --neutral-950: oklch(98% 0.01 85);
+  --neutral-900: oklch(95% 0.015 85);
+  --neutral-800: oklch(90% 0.02 85);
+  --neutral-700: oklch(80% 0.025 85);
+  --neutral-400: oklch(42% 0.025 70);
+  --neutral-100: oklch(20% 0.02 70);
+  --blue-600: oklch(52% 0.15 45);
+}
+
+[data-theme="electric"] {
+  --neutral-950: oklch(12% 0.06 290);
+  --neutral-900: oklch(17% 0.07 290);
+  --neutral-800: oklch(23% 0.08 290);
+  --neutral-700: oklch(34% 0.1 290);
+  --neutral-400: oklch(76% 0.08 230);
+  --neutral-100: oklch(96% 0.03 210);
+  --blue-600: oklch(76% 0.2 195);
+}
+
+[data-mode="light"] {
+  --background: oklch(98% 0.01 85);
+  --foreground: oklch(20% 0.02 70);
+  --card: oklch(95% 0.015 85);
+  --card-foreground: oklch(20% 0.02 70);
+  --popover: oklch(95% 0.015 85);
+  --popover-foreground: oklch(20% 0.02 70);
+  --secondary: oklch(92% 0.02 85);
+  --secondary-foreground: oklch(20% 0.02 70);
+  --muted: oklch(92% 0.02 85);
+  --muted-foreground: oklch(42% 0.025 70);
+  --border: oklch(80% 0.025 85);
+  --input: oklch(90% 0.02 85);
+}
+
+[data-mode="dark"] {
+  --background: oklch(5.5% 0 0);
+  --foreground: oklch(98.5% 0 0);
+  --card: oklch(10.5% 0 0);
+  --card-foreground: oklch(98.5% 0 0);
+  --popover: oklch(10.5% 0 0);
+  --popover-foreground: oklch(98.5% 0 0);
+  --secondary: oklch(10.5% 0 0);
+  --secondary-foreground: oklch(98.5% 0 0);
+  --muted: oklch(10.5% 0 0);
+  --muted-foreground: oklch(69% 0 0);
+  --border: oklch(24% 0 0);
+  --input: oklch(16% 0 0);
+}
+
+[data-radius="compact"] {
+  --radius: 0rem;
+}
+[data-radius="medium"] {
+  --radius: 0.5rem;
+}
+[data-radius="rounded"] {
+  --radius: 1rem;
+}
+[data-density="compact"] {
+  --shell-padding-y: 1.25rem;
+}
+[data-density="comfortable"] {
+  --shell-padding-y: 2rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  [data-mode="system"] {
+    --background: oklch(5.5% 0 0);
+    --foreground: oklch(98.5% 0 0);
+    --card: oklch(10.5% 0 0);
+    --card-foreground: oklch(98.5% 0 0);
+    --popover: oklch(10.5% 0 0);
+    --popover-foreground: oklch(98.5% 0 0);
+    --secondary: oklch(10.5% 0 0);
+    --secondary-foreground: oklch(98.5% 0 0);
+    --muted: oklch(10.5% 0 0);
+    --muted-foreground: oklch(69% 0 0);
+    --border: oklch(24% 0 0);
+    --input: oklch(16% 0 0);
+  }
+}
+
+@media (prefers-color-scheme: light) {
+  [data-mode="system"] {
+    --background: oklch(98% 0.01 85);
+    --foreground: oklch(20% 0.02 70);
+    --card: oklch(95% 0.015 85);
+    --card-foreground: oklch(20% 0.02 70);
+    --popover: oklch(95% 0.015 85);
+    --popover-foreground: oklch(20% 0.02 70);
+    --secondary: oklch(92% 0.02 85);
+    --secondary-foreground: oklch(20% 0.02 70);
+    --muted: oklch(92% 0.02 85);
+    --muted-foreground: oklch(42% 0.025 70);
+    --border: oklch(80% 0.025 85);
+    --input: oklch(90% 0.02 85);
+  }
+}
+
 @theme inline {
-  --radius-sm: 0rem;
-  --radius-md: 0rem;
-  --radius-lg: 0rem;
-  --radius-xl: 0rem;
+  --radius-sm: calc(var(--radius) * 0.5);
+  --radius-md: var(--radius);
+  --radius-lg: calc(var(--radius) * 1.5);
+  --radius-xl: calc(var(--radius) * 2);
 
   --color-background: var(--background);
   --color-foreground: var(--foreground);
@@ -101,7 +202,9 @@
     min-height: 100%;
     background: var(--background);
     color: var(--foreground);
-    font-family: var(--font-mono), ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-family:
+      var(--font-mono), ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+      monospace;
     text-rendering: geometricPrecision;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
@@ -113,7 +216,11 @@
     background:
       linear-gradient(oklch(69% 0 0 / 0.12) 1px, transparent 1px),
       linear-gradient(90deg, oklch(69% 0 0 / 0.12) 1px, transparent 1px),
-      radial-gradient(circle at 0% 0%, oklch(51% 0.245 264 / 0.36), transparent 30rem),
+      radial-gradient(
+        circle at 0% 0%,
+        color-mix(in oklch, var(--primary) 36%, transparent),
+        transparent 30rem
+      ),
       var(--background);
     background-attachment: fixed;
     background-size:
@@ -122,6 +229,10 @@
       auto,
       auto;
     color: var(--foreground);
+  }
+
+  .lv-shell-main {
+    padding-block: var(--shell-padding-y);
   }
 
   :focus-visible {

--- a/templates/golden/app/layout.tsx
+++ b/templates/golden/app/layout.tsx
@@ -3,6 +3,8 @@ import { Archivo_Black, Bebas_Neue, JetBrains_Mono } from "next/font/google"
 import type { ReactNode } from "react"
 
 import { AppProviders } from "@/components/app/app-providers"
+import { loadedVibesDesign } from "@/content/loadedvibes"
+import { site } from "@/content/site"
 import "./globals.css"
 
 const archivoBlack = Archivo_Black({
@@ -30,13 +32,12 @@ const appUrl = process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000"
 
 export const metadata: Metadata = {
   metadataBase: new URL(appUrl),
-  applicationName: "Next Stack Template",
+  applicationName: site.name,
   title: {
-    default: "Next Stack Template",
-    template: "%s - Next Stack Template",
+    default: site.name,
+    template: `%s - ${site.name}`,
   },
-  description:
-    "A strict App Router SaaS template with Clerk auth, row-level RBAC, Prisma, Neon, Server Actions, and Tailwind CSS v4.",
+  description: site.description,
   alternates: {
     canonical: "/",
   },
@@ -50,8 +51,13 @@ export const metadata: Metadata = {
 }
 
 export const viewport: Viewport = {
-  themeColor: "#0a0a0a",
-  colorScheme: "dark",
+  themeColor:
+    loadedVibesDesign.theme === "paper"
+      ? "#f7f5ef"
+      : loadedVibesDesign.theme === "electric"
+        ? "#10072b"
+        : "#0a0a0a",
+  colorScheme: loadedVibesDesign.mode === "system" ? "light dark" : loadedVibesDesign.mode,
   width: "device-width",
   initialScale: 1,
 }
@@ -65,6 +71,10 @@ export default function RootLayout({ children }: RootLayoutProps) {
     <html
       lang="en"
       className={`${archivoBlack.variable} ${bebasNeue.variable} ${jetBrainsMono.variable}`}
+      data-theme={loadedVibesDesign.theme}
+      data-mode={loadedVibesDesign.mode}
+      data-radius={loadedVibesDesign.radius}
+      data-density={loadedVibesDesign.density}
       suppressHydrationWarning
     >
       <body className="min-h-dvh overflow-x-hidden bg-background">

--- a/templates/golden/app/page.tsx
+++ b/templates/golden/app/page.tsx
@@ -5,15 +5,12 @@ import { ProcessPanel } from "@/components/blocks/process-panel"
 import { StatGrid } from "@/components/blocks/stat-grid"
 import { Button } from "@/components/ui/button"
 import { loadedVibesCapabilities } from "@/content/loadedvibes"
+import { site } from "@/content/site"
 
 export default function HomePage() {
   return (
     <div className="grid gap-10">
-      <PageHero
-        eyebrow="Generic SaaS starter"
-        title="Build the app, not the boundary map."
-        description="A strict App Router template for server-owned SaaS workflows, Clerk identity, local row-level authorization, Server Actions, Prisma, and Neon."
-      />
+      <PageHero eyebrow="Generic SaaS starter" title={site.name} description={site.description} />
       <div className="flex flex-wrap gap-3">
         <Button asChild>
           <Link href="/sign-up">Start the app</Link>

--- a/templates/golden/components/brand/logo-lockup.tsx
+++ b/templates/golden/components/brand/logo-lockup.tsx
@@ -1,3 +1,5 @@
+import { site } from "@/content/site"
+
 export function LogoLockup() {
-  return <span className="text-lg font-black tracking-tight text-white uppercase">Next Stack</span>
+  return <span className="text-lg font-black tracking-tight uppercase">{site.name}</span>
 }

--- a/templates/golden/components/brand/wordmark.tsx
+++ b/templates/golden/components/brand/wordmark.tsx
@@ -1,12 +1,16 @@
 import Link from "next/link"
 
+import { site } from "@/content/site"
+
 export function Wordmark() {
+  const mark = site.name.trim().charAt(0).toUpperCase()
+
   return (
     <Link href="/" className="flex items-center gap-3 no-underline">
       <span className="grid size-8 place-items-center border border-primary bg-primary text-sm font-black text-primary-foreground">
-        N
+        {mark}
       </span>
-      <span className="font-display text-2xl leading-none uppercase">Next Stack</span>
+      <span className="font-display text-2xl leading-none uppercase">{site.name}</span>
     </Link>
   )
 }

--- a/templates/golden/components/shells/tenant-shell.tsx
+++ b/templates/golden/components/shells/tenant-shell.tsx
@@ -5,7 +5,7 @@ import type { ReactNode } from "react"
 
 import { Wordmark } from "@/components/brand/wordmark"
 import { Button } from "@/components/ui/button"
-import { loadedVibesCapabilities } from "@/content/loadedvibes"
+import { loadedVibesCapabilities, loadedVibesDesign } from "@/content/loadedvibes"
 
 type TenantShellProps = {
   children: ReactNode
@@ -20,14 +20,22 @@ const navItems = [
 ] as const
 
 export function TenantShell({ children }: TenantShellProps) {
+  const sidebar = loadedVibesDesign.navigation === "sidebar"
+
   return (
-    <div className="min-h-dvh pb-20 md:pb-0">
-      <header className="sticky top-0 z-40 border-b bg-background/90 backdrop-blur">
-        <div className="mx-auto flex h-16 w-full max-w-7xl items-center justify-between px-6 sm:px-10 lg:px-12">
+    <div
+      className={
+        sidebar
+          ? "min-h-dvh pb-20 md:grid md:grid-cols-[15rem_1fr] md:pb-0"
+          : "min-h-dvh pb-20 md:pb-0"
+      }
+    >
+      {sidebar ? (
+        <aside className="sticky top-0 hidden h-dvh border-r bg-background/90 p-6 backdrop-blur md:flex md:flex-col md:gap-8">
           <Wordmark />
-          <nav className="hidden items-center gap-2 md:flex">
+          <nav className="grid gap-2">
             {navItems.map((item) => (
-              <Button key={item.href} asChild variant="ghost" size="sm">
+              <Button key={item.href} asChild variant="ghost" className="justify-start">
                 <Link href={item.href}>
                   <item.icon className="size-4" />
                   {item.label}
@@ -35,22 +43,46 @@ export function TenantShell({ children }: TenantShellProps) {
               </Button>
             ))}
           </nav>
-          <UserButton />
-        </div>
-      </header>
-      <main className="mx-auto w-full max-w-7xl px-6 py-8 sm:px-10 lg:px-12">{children}</main>
-      <nav className="fixed inset-x-0 bottom-0 z-50 grid grid-cols-3 border-t bg-background md:hidden">
-        {navItems.map((item) => (
-          <Link
-            key={item.href}
-            href={item.href}
-            className="flex min-h-16 flex-col items-center justify-center gap-1 text-xs text-muted-foreground no-underline"
-          >
-            <item.icon className="size-5" />
-            {item.label}
-          </Link>
-        ))}
-      </nav>
+          <div className="mt-auto">
+            <UserButton />
+          </div>
+        </aside>
+      ) : null}
+      <div className="min-w-0">
+        <header
+          className={`sticky top-0 z-40 border-b bg-background/90 backdrop-blur ${sidebar ? "md:hidden" : ""}`}
+        >
+          <div className="mx-auto flex h-16 w-full max-w-7xl items-center justify-between px-6 sm:px-10 lg:px-12">
+            <Wordmark />
+            <nav className="hidden items-center gap-2 md:flex">
+              {navItems.map((item) => (
+                <Button key={item.href} asChild variant="ghost" size="sm">
+                  <Link href={item.href}>
+                    <item.icon className="size-4" />
+                    {item.label}
+                  </Link>
+                </Button>
+              ))}
+            </nav>
+            <UserButton />
+          </div>
+        </header>
+        <main className="lv-shell-main mx-auto w-full max-w-7xl px-6 sm:px-10 lg:px-12">
+          {children}
+        </main>
+        <nav className="fixed inset-x-0 bottom-0 z-50 grid grid-cols-3 border-t bg-background md:hidden">
+          {navItems.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className="flex min-h-16 flex-col items-center justify-center gap-1 text-xs text-muted-foreground no-underline"
+            >
+              <item.icon className="size-5" />
+              {item.label}
+            </Link>
+          ))}
+        </nav>
+      </div>
     </div>
   )
 }

--- a/templates/golden/content/loadedvibes.ts
+++ b/templates/golden/content/loadedvibes.ts
@@ -1,3 +1,24 @@
+export const loadedVibesProduct = {
+  name: "Next Stack",
+  description: "A focused SaaS product built with Loaded Vibes.",
+} as const
+
+export type LoadedVibesDesign = {
+  theme: "obsidian" | "paper" | "electric"
+  radius: "compact" | "medium" | "rounded"
+  density: "compact" | "comfortable"
+  navigation: "sidebar" | "topbar"
+  mode: "light" | "dark" | "system"
+}
+
+export const loadedVibesDesign: LoadedVibesDesign = {
+  theme: "obsidian",
+  radius: "medium",
+  density: "comfortable",
+  navigation: "sidebar",
+  mode: "system",
+}
+
 export const loadedVibesCapabilities = {
   marketing: false,
   sampleDomain: false,

--- a/templates/golden/content/site.ts
+++ b/templates/golden/content/site.ts
@@ -1,5 +1,6 @@
+import { loadedVibesProduct } from "@/content/loadedvibes"
+
 export const site = {
-  name: "Next Stack Template",
-  description:
-    "A strict App Router SaaS template with Clerk auth, local row-level RBAC, Prisma, Neon, and Server Actions.",
+  name: loadedVibesProduct.name,
+  description: loadedVibesProduct.description,
 }

--- a/tests/integration/materialize.test.ts
+++ b/tests/integration/materialize.test.ts
@@ -161,6 +161,57 @@ describe('createProject', () => {
     await assertLocalImportsResolve(target);
   });
 
+  it('wires product identity and semantic design choices into known surfaces', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'loaded-vibes-design-'));
+    const target = path.join(root, 'signal-desk');
+    await createProject({
+      name: 'signal-desk',
+      product: 'bare-golden-app',
+      identity: {
+        displayName: 'Signal Desk',
+        description: 'Decisions without the meeting sprawl.',
+      },
+      design: {
+        theme: 'paper',
+        mode: 'light',
+        radius: 'rounded',
+        density: 'compact',
+        navigation: 'topbar',
+      },
+      targetDirectory: target,
+      git: { initialize: false },
+      install: { enabled: false },
+    });
+    const generatedDesign = await readFile(
+      path.join(target, 'content', 'loadedvibes.ts'),
+      'utf8',
+    );
+    expect(generatedDesign).toContain('"name": "Signal Desk"');
+    expect(generatedDesign).toContain(
+      '"description": "Decisions without the meeting sprawl."',
+    );
+    expect(generatedDesign).toContain('"theme": "paper"');
+    expect(generatedDesign).toContain('"radius": "rounded"');
+    expect(generatedDesign).toContain('"density": "compact"');
+    expect(generatedDesign).toContain('"navigation": "topbar"');
+    expect(generatedDesign).toContain('"mode": "light"');
+    await expect(
+      readFile(path.join(target, 'app', 'layout.tsx'), 'utf8'),
+    ).resolves.toContain('data-theme={loadedVibesDesign.theme}');
+    await expect(
+      readFile(path.join(target, 'app', 'globals.css'), 'utf8'),
+    ).resolves.toContain('[data-theme="paper"]');
+    await expect(
+      readFile(
+        path.join(target, 'components', 'shells', 'tenant-shell.tsx'),
+        'utf8',
+      ),
+    ).resolves.toContain('loadedVibesDesign.navigation === "sidebar"');
+    await expect(
+      readFile(path.join(target, 'content', 'site.ts'), 'utf8'),
+    ).resolves.toContain('name: loadedVibesProduct.name');
+  });
+
   it('does not attempt to recreate an existing filesystem-root parent', async () => {
     const root = await mkdtemp(
       path.join(os.tmpdir(), 'loaded-vibes-root-parent-'),


### PR DESCRIPTION
## Summary
- emit a typed generated product/design contract from the shared recipe
- apply product identity to metadata, homepage, and brand surfaces
- add obsidian, paper, and electric semantic token directions with bounded mode, radius, and density controls
- render the tenant application with the selected sidebar or topbar shell

## QA
- corepack pnpm exec vitest run tests/integration/materialize.test.ts (5 passed)
- corepack pnpm typecheck
- corepack pnpm lint
- corepack pnpm format:check
- corepack pnpm test:generated (5 passed)

## Scope notes
- transforms write known generated contracts and consume them at intentional surfaces; no source-wide replacement is used
- domain, security, and provider names are untouched

Closes #96