### PR TITLE
feat(cli): add supported modules after generation

### DIFF
--- a/.agents/execution/decisions.json
+++ b/.agents/execution/decisions.json
@@ -32,6 +32,12 @@
       "decision": "Generated identity and design choices are exposed through one typed product contract and consumed only by metadata, brand, semantic token, density, and navigation-shell surfaces.",
       "status": "active",
       "issue": 96
+    },
+    {
+      "id": "LV-D-007",
+      "decision": "Post-generation add is limited to packaged repository modules, preflights every file, and permits declared replacements only while the destination still matches the golden baseline.",
+      "status": "active",
+      "issue": 97
     }
   ]
 }

--- a/.agents/execution/handoff.json
+++ b/.agents/execution/handoff.json
@@ -1,19 +1,20 @@
 {
   "schemaVersion": 2,
   "status": "in-progress",
-  "currentOutcome": "LV-105 product identity and semantic design personalization implemented on feature/96-design-personalization.",
-  "activeIssue": 96,
-  "activeBranch": "feature/96-design-personalization",
-  "activePullRequest": "https://github.com/DigitalHerencia/LoadedVibes/pull/106",
-  "lastCompletedIssue": 95,
-  "lastMergedPullRequest": "https://github.com/DigitalHerencia/LoadedVibes/pull/105",
-  "nextAction": "Open and review the Issue #96 pull request, then merge when its acceptance criteria remain satisfied.",
+  "currentOutcome": "LV-106 generation manifest and safe post-generation module addition implemented on feature/97-post-generation-add.",
+  "activeIssue": 97,
+  "activeBranch": "feature/97-post-generation-add",
+  "activePullRequest": null,
+  "lastCompletedIssue": 96,
+  "lastMergedPullRequest": "https://github.com/DigitalHerencia/LoadedVibes/pull/106",
+  "nextAction": "Open and review the Issue #97 pull request, then merge when its acceptance criteria remain satisfied.",
   "executedEvidence": [
-    "corepack pnpm exec vitest run tests/integration/materialize.test.ts (5 tests passed)",
+    "corepack pnpm exec vitest run tests/unit/config.test.ts tests/unit/recipe-resolution.test.ts tests/integration/add-module.test.ts tests/integration/materialize.test.ts (21 tests passed)",
     "corepack pnpm typecheck",
     "corepack pnpm lint",
     "corepack pnpm format:check",
-    "corepack pnpm test:generated (5 tests passed)"
+    "corepack pnpm test:generated (6 tests passed)",
+    "corepack pnpm pack:check (345 safe entries)"
   ],
   "blockedEvidence": [],
   "notes": [

--- a/.agents/execution/handoff.json
+++ b/.agents/execution/handoff.json
@@ -4,7 +4,7 @@
   "currentOutcome": "LV-106 generation manifest and safe post-generation module addition implemented on feature/97-post-generation-add.",
   "activeIssue": 97,
   "activeBranch": "feature/97-post-generation-add",
-  "activePullRequest": null,
+  "activePullRequest": "https://github.com/DigitalHerencia/LoadedVibes/pull/107",
   "lastCompletedIssue": 96,
   "lastMergedPullRequest": "https://github.com/DigitalHerencia/LoadedVibes/pull/106",
   "nextAction": "Open and review the Issue #97 pull request, then merge when its acceptance criteria remain satisfied.",

--- a/.agents/execution/progress.json
+++ b/.agents/execution/progress.json
@@ -100,7 +100,7 @@
       "issue": 97,
       "status": "implemented",
       "branch": "feature/97-post-generation-add",
-      "pullRequest": null,
+      "pullRequest": "https://github.com/DigitalHerencia/LoadedVibes/pull/107",
       "evidence": {
         "executed": [
           "corepack pnpm exec vitest run tests/unit/config.test.ts tests/unit/recipe-resolution.test.ts tests/integration/add-module.test.ts tests/integration/materialize.test.ts (21 tests passed)",

--- a/.agents/execution/progress.json
+++ b/.agents/execution/progress.json
@@ -2,9 +2,9 @@
   "schemaVersion": 2,
   "roadmap": "generator-product-roadmap",
   "status": "in_progress",
-  "activeIssue": 96,
-  "activeBranch": "feature/96-design-personalization",
-  "completed": [92, 93, 94, 95],
+  "activeIssue": 97,
+  "activeBranch": "feature/97-post-generation-add",
+  "completed": [92, 93, 94, 95, 96],
   "workItems": [
     {
       "id": "LV-101",
@@ -81,7 +81,7 @@
     {
       "id": "LV-105",
       "issue": 96,
-      "status": "implemented",
+      "status": "verified",
       "branch": "feature/96-design-personalization",
       "pullRequest": "https://github.com/DigitalHerencia/LoadedVibes/pull/106",
       "evidence": {
@@ -91,6 +91,24 @@
           "corepack pnpm lint",
           "corepack pnpm format:check",
           "corepack pnpm test:generated (5 tests passed)"
+        ],
+        "blocked": []
+      }
+    },
+    {
+      "id": "LV-106",
+      "issue": 97,
+      "status": "implemented",
+      "branch": "feature/97-post-generation-add",
+      "pullRequest": null,
+      "evidence": {
+        "executed": [
+          "corepack pnpm exec vitest run tests/unit/config.test.ts tests/unit/recipe-resolution.test.ts tests/integration/add-module.test.ts tests/integration/materialize.test.ts (21 tests passed)",
+          "corepack pnpm typecheck",
+          "corepack pnpm lint",
+          "corepack pnpm format:check",
+          "corepack pnpm test:generated (6 tests passed)",
+          "corepack pnpm pack:check (345 safe entries)"
         ],
         "blocked": []
       }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Loaded Vibes
 
-Loaded Vibes is an opinionated SaaS project initializer. It generates the canonical, governed Hipster Stack application embedded in `template/`; it is not a stack selector or blank scaffold.
+Loaded Vibes is an opinionated SaaS project initializer. It generates the canonical, governed Hipster Stack application from the packaged `templates/golden/` baseline; it is not a stack selector or blank scaffold.
 
 ```powershell
 pnpm dlx create-loaded-vibes@latest my-product
@@ -15,5 +15,15 @@ corepack pnpm dev -- my-product --yes
 ```
 
 Use `--config <path>` for versioned non-interactive JSON configuration, `--dry-run` to inspect the plan, `--no-git` to skip Git initialization, or `--skip-install` to generate without claiming acceptance validation.
+
+Generated projects include `.loadedvibes/manifest.json`. From a generated project, an installed CLI can add one explicitly supported capability overlay:
+
+```powershell
+loaded-vibes add marketing
+loaded-vibes add sample-domain
+loaded-vibes add stripe-connect
+```
+
+The command resolves capability prerequisites, previews files and setup, and refuses user-modified collisions. It does not merge arbitrary template upgrades.
 
 The canonical product and architecture sources live in [`context/`](context/README.md). Machine contracts and execution evidence live in [`.agents/`](.agents/AGENTS.md).

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "node": "24.x"
   },
   "bin": {
-    "create-loaded-vibes": "dist/cli.mjs"
+    "create-loaded-vibes": "dist/cli.mjs",
+    "loaded-vibes": "dist/cli.mjs"
   },
   "files": [
     "dist",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -2,9 +2,11 @@ import path from 'node:path';
 import { Command } from 'commander';
 import { cancel, intro, isCancel, outro, spinner, text } from '@clack/prompts';
 import {
+  applyProjectModuleAddition,
   createProject,
   loadConfigFile,
   LoadedVibesError,
+  planProjectModuleAddition,
   resolveRecipe,
   type ConfigInput,
   type RecipeInput,
@@ -17,7 +19,7 @@ import {
 
 const program = new Command();
 program
-  .name('create-loaded-vibes')
+  .name('loaded-vibes')
   .description('Generate a complete Loaded Vibes SaaS project.')
   .version('0.1.0')
   .argument('[target-directory]')
@@ -128,6 +130,38 @@ program
         `Generated ${recipe.name}; install and acceptance validation were skipped.`,
       );
     }
+  });
+
+program
+  .command('add')
+  .description('Add a supported Loaded Vibes capability module.')
+  .argument('<module>', 'marketing, sample-domain, or stripe-connect')
+  .option('--cwd <directory>', 'generated project directory', '.')
+  .action(async (module: string, flags: { cwd: string }) => {
+    intro('Loaded Vibes add');
+    const plan = await planProjectModuleAddition(flags.cwd, module);
+    console.log(
+      [
+        `Module: ${plan.module}`,
+        `Capabilities: ${plan.addedCapabilities.join(', ')}`,
+        `Prerequisites: ${plan.prerequisites.join(', ') || 'none'}`,
+        `Files: ${plan.files.length} (${plan.replacements.length} intentional replacement${plan.replacements.length === 1 ? '' : 's'})`,
+        `Setup: ${plan.setup.length ? plan.setup.join(' ') : 'none'}`,
+      ].join('\n'),
+    );
+    const progress = spinner();
+    progress.start(`Adding ${plan.module}`);
+    let result;
+    try {
+      result = await applyProjectModuleAddition(plan);
+    } catch (error) {
+      progress.stop('Module addition stopped');
+      throw error;
+    }
+    progress.stop(`Added ${result.module}`);
+    outro(
+      `${result.filesAdded.length} files added, ${result.filesReplaced.length} updated. ${result.setup.join(' ')}`.trim(),
+    );
   });
 
 program.parseAsync().catch((error: unknown) => {

--- a/packages/core/src/commands/add.ts
+++ b/packages/core/src/commands/add.ts
@@ -1,0 +1,243 @@
+import { access, cp, mkdir, readFile, readdir } from 'node:fs/promises';
+import path from 'node:path';
+import type {
+  CapabilityId,
+  ModuleSelection,
+  NormalizedRecipe,
+} from '@loaded-vibes/schema';
+import { LoadedVibesError } from '../errors.js';
+import { generatedModuleIds, type GeneratedModuleId } from '../modules.js';
+import {
+  parseGenerationManifest,
+  type GenerationManifest,
+} from '../manifest.js';
+import { resolveRecipe } from '../recipe.js';
+import { writeRecipeArtifacts } from '../generator/transforms.js';
+import { resolveTemplateDirectory } from './create.js';
+
+interface ModuleMetadata {
+  id: GeneratedModuleId;
+  contributions: string[];
+  replaces: string[];
+  setup: string[];
+}
+
+export interface ModuleAdditionPlan {
+  targetDirectory: string;
+  module: GeneratedModuleId;
+  addedCapabilities: CapabilityId[];
+  prerequisites: CapabilityId[];
+  files: string[];
+  replacements: string[];
+  setup: string[];
+  nextRecipe: NormalizedRecipe;
+  manifest: GenerationManifest;
+  sourceDirectory: string;
+  templateDirectory: string;
+}
+
+export interface ModuleAdditionResult {
+  module: GeneratedModuleId;
+  addedCapabilities: CapabilityId[];
+  prerequisites: CapabilityId[];
+  filesAdded: string[];
+  filesReplaced: string[];
+  setup: string[];
+}
+
+const moduleCapabilities = {
+  marketing: 'marketing',
+  'sample-domain': 'sampleDomain',
+  'stripe-connect': 'stripeConnect',
+} as const satisfies Record<GeneratedModuleId, CapabilityId>;
+
+function isEnabled(recipe: NormalizedRecipe, id: CapabilityId): boolean {
+  return id === 'sampleDomain'
+    ? recipe.modules.sampleDomain !== false
+    : recipe.modules[id];
+}
+
+function parseModuleId(value: string): GeneratedModuleId {
+  if ((generatedModuleIds as readonly string[]).includes(value))
+    return value as GeneratedModuleId;
+  throw new LoadedVibesError(
+    'MODULE_UNSUPPORTED',
+    `Unsupported module "${value}". Supported modules: ${generatedModuleIds.join(', ')}.`,
+  );
+}
+
+async function readJson(file: string): Promise<unknown> {
+  try {
+    return JSON.parse(await readFile(file, 'utf8')) as unknown;
+  } catch (error) {
+    throw new LoadedVibesError(
+      'PROJECT_NOT_GENERATED',
+      `Unable to read generated project metadata at ${file}.`,
+      error,
+    );
+  }
+}
+
+async function readModuleMetadata(
+  sourceDirectory: string,
+  expectedId: GeneratedModuleId,
+): Promise<ModuleMetadata> {
+  const value = (await readJson(
+    path.join(sourceDirectory, '.loaded-vibes-module.json'),
+  )) as Partial<ModuleMetadata>;
+  if (value.id !== expectedId || !Array.isArray(value.contributions)) {
+    throw new LoadedVibesError(
+      'MODULE_UNSUPPORTED',
+      `Packaged metadata for module "${expectedId}" is invalid.`,
+    );
+  }
+  return {
+    id: expectedId,
+    contributions: value.contributions,
+    replaces: Array.isArray(value.replaces) ? value.replaces : [],
+    setup: Array.isArray(value.setup) ? value.setup : [],
+  };
+}
+
+async function listFiles(
+  directory: string,
+  root = directory,
+): Promise<string[]> {
+  const files: string[] = [];
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    if (entry.name === '.loaded-vibes-module.json') continue;
+    const absolute = path.join(directory, entry.name);
+    if (entry.isDirectory()) files.push(...(await listFiles(absolute, root)));
+    else files.push(path.relative(root, absolute));
+  }
+  return files;
+}
+
+async function exists(file: string): Promise<boolean> {
+  try {
+    await access(file);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function assertAdditionIsSafe(plan: ModuleAdditionPlan): Promise<void> {
+  for (const relative of plan.files) {
+    const destination = path.join(plan.targetDirectory, relative);
+    if (!(await exists(destination))) continue;
+    if (!plan.replacements.includes(relative)) {
+      throw new LoadedVibesError(
+        'MODULE_CONFLICT',
+        `Module "${plan.module}" would overwrite ${relative}. No files were changed.`,
+      );
+    }
+    const baseline = path.join(plan.templateDirectory, relative);
+    if (!(await exists(baseline))) {
+      throw new LoadedVibesError(
+        'MODULE_CONFLICT',
+        `Module replacement baseline is missing for ${relative}. No files were changed.`,
+      );
+    }
+    const [currentBody, baselineBody] = await Promise.all([
+      readFile(destination),
+      readFile(baseline),
+    ]);
+    if (!currentBody.equals(baselineBody)) {
+      throw new LoadedVibesError(
+        'MODULE_CONFLICT',
+        `${relative} has changed since generation. Loaded Vibes will not overwrite it.`,
+      );
+    }
+  }
+}
+
+export async function planProjectModuleAddition(
+  targetDirectory: string,
+  requestedModule: string,
+): Promise<ModuleAdditionPlan> {
+  const target = path.resolve(targetDirectory);
+  const module = parseModuleId(requestedModule);
+  const manifest = parseGenerationManifest(
+    await readJson(path.join(target, '.loadedvibes', 'manifest.json')),
+  );
+  const currentRecipe = resolveRecipe(
+    (await readJson(path.join(target, 'loadedvibes.json'))) as NormalizedRecipe,
+  ).recipe;
+  if (JSON.stringify(manifest.recipe) !== JSON.stringify(currentRecipe)) {
+    throw new LoadedVibesError(
+      'MODULE_CONFLICT',
+      'loadedvibes.json and .loadedvibes/manifest.json disagree. Reconcile them before adding a module.',
+    );
+  }
+  const capability = moduleCapabilities[module];
+  if (isEnabled(currentRecipe, capability)) {
+    throw new LoadedVibesError(
+      'MODULE_ALREADY_PRESENT',
+      `Module "${module}" is already present.`,
+    );
+  }
+  const override: ModuleSelection =
+    capability === 'sampleDomain'
+      ? { sampleDomain: 'projects' }
+      : { [capability]: true };
+  const nextRecipe = resolveRecipe({
+    ...currentRecipe,
+    modules: { ...currentRecipe.modules, ...override },
+  }).recipe;
+  const addedCapabilities = (
+    Object.keys(nextRecipe.modules) as CapabilityId[]
+  ).filter((id) => !isEnabled(currentRecipe, id) && isEnabled(nextRecipe, id));
+  const templateDirectory = await resolveTemplateDirectory();
+  const sourceDirectory = path.resolve(
+    templateDirectory,
+    '..',
+    'modules',
+    module,
+  );
+  const metadata = await readModuleMetadata(sourceDirectory, module);
+  const files = await listFiles(sourceDirectory);
+  const plan: ModuleAdditionPlan = {
+    targetDirectory: target,
+    module,
+    addedCapabilities,
+    prerequisites: addedCapabilities.filter((id) => id !== capability),
+    files,
+    replacements: metadata.replaces,
+    setup: metadata.setup,
+    nextRecipe,
+    manifest,
+    sourceDirectory,
+    templateDirectory,
+  };
+  await assertAdditionIsSafe(plan);
+  return plan;
+}
+
+export async function applyProjectModuleAddition(
+  plan: ModuleAdditionPlan,
+): Promise<ModuleAdditionResult> {
+  await assertAdditionIsSafe(plan);
+  for (const relative of plan.files) {
+    const destination = path.join(plan.targetDirectory, relative);
+    await mkdir(path.dirname(destination), { recursive: true });
+    await cp(path.join(plan.sourceDirectory, relative), destination, {
+      force: plan.replacements.includes(relative),
+      errorOnExist: !plan.replacements.includes(relative),
+    });
+  }
+  await writeRecipeArtifacts(plan.targetDirectory, plan.nextRecipe, {
+    templateRevision: plan.manifest.template.revision,
+    sourceRevision: plan.manifest.template.sourceRevision,
+  });
+  return {
+    module: plan.module,
+    addedCapabilities: plan.addedCapabilities,
+    prerequisites: plan.prerequisites,
+    filesAdded: plan.files.filter((file) => !plan.replacements.includes(file)),
+    filesReplaced: plan.files.filter((file) =>
+      plan.replacements.includes(file),
+    ),
+    setup: plan.setup,
+  };
+}

--- a/packages/core/src/commands/create.ts
+++ b/packages/core/src/commands/create.ts
@@ -14,7 +14,7 @@ export interface CreateOptions {
   dryRun?: boolean;
 }
 
-async function resolveTemplateDirectory(): Promise<string> {
+export async function resolveTemplateDirectory(): Promise<string> {
   const moduleDirectory = path.dirname(fileURLToPath(import.meta.url));
   const candidates = [
     path.resolve(moduleDirectory, '../../../../templates/golden'),

--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -1,9 +1,9 @@
 import { z } from 'zod';
-import { recipeSchema } from '@loaded-vibes/schema';
+import { normalizedRecipeSchema } from '@loaded-vibes/schema';
 
 export const loadedVibesConfigSchema = z
   .object({
-    recipe: recipeSchema,
+    recipe: normalizedRecipeSchema,
     targetDirectory: z.string().min(1),
     git: z
       .object({ initialize: z.boolean() })

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -9,7 +9,11 @@ export type LoadedVibesErrorCode =
   | 'TRANSFORM_FAILED'
   | 'INSTALL_FAILED'
   | 'VALIDATION_FAILED'
-  | 'GIT_INIT_FAILED';
+  | 'GIT_INIT_FAILED'
+  | 'PROJECT_NOT_GENERATED'
+  | 'MODULE_UNSUPPORTED'
+  | 'MODULE_ALREADY_PRESENT'
+  | 'MODULE_CONFLICT';
 
 export class LoadedVibesError extends Error {
   constructor(

--- a/packages/core/src/generator/transforms.ts
+++ b/packages/core/src/generator/transforms.ts
@@ -1,6 +1,134 @@
-import { readFile, rename, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
 import path from 'node:path';
+import type { NormalizedRecipe } from '@loaded-vibes/schema';
+import { selectedGeneratedModuleIds } from '../modules.js';
 import type { GenerationPlan } from './plan.js';
+
+export interface TemplateProvenance {
+  templateRevision: string;
+  sourceRevision: string;
+}
+
+export async function writeRecipeArtifacts(
+  directory: string,
+  recipe: NormalizedRecipe,
+  template: TemplateProvenance,
+): Promise<void> {
+  await writeFile(
+    path.join(directory, 'loadedvibes.json'),
+    `${JSON.stringify(recipe, null, 2)}\n`,
+  );
+  await mkdir(path.join(directory, '.loadedvibes'), { recursive: true });
+  await writeFile(
+    path.join(directory, '.loadedvibes', 'manifest.json'),
+    `${JSON.stringify(
+      {
+        schemaVersion: 1,
+        generator: { name: 'create-loaded-vibes', version: '0.1.0' },
+        template: {
+          revision: template.templateRevision,
+          sourceRevision: template.sourceRevision,
+        },
+        preset: recipe.product,
+        modules: selectedGeneratedModuleIds(recipe),
+        recipe,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  await writeProductContract(directory, recipe);
+  await writeRoutesContract(directory, recipe);
+}
+
+async function writeProductContract(
+  directory: string,
+  recipe: NormalizedRecipe,
+): Promise<void> {
+  const capabilitiesSource = `export const loadedVibesProduct = ${JSON.stringify(
+    {
+      name: recipe.identity.displayName,
+      description:
+        recipe.identity.description ||
+        'A focused SaaS product built with Loaded Vibes.',
+    },
+    null,
+    2,
+  )} as const
+
+export type LoadedVibesDesign = {
+  theme: "obsidian" | "paper" | "electric"
+  radius: "compact" | "medium" | "rounded"
+  density: "compact" | "comfortable"
+  navigation: "sidebar" | "topbar"
+  mode: "light" | "dark" | "system"
+}
+
+export const loadedVibesDesign: LoadedVibesDesign = ${JSON.stringify(
+    recipe.design,
+    null,
+    2,
+  )}
+
+export const loadedVibesCapabilities = ${JSON.stringify(
+    {
+      marketing: recipe.modules.marketing,
+      sampleDomain: recipe.modules.sampleDomain !== false,
+      stripeConnect: recipe.modules.stripeConnect,
+    },
+    null,
+    2,
+  )} as const\n`;
+  await writeFile(
+    path.join(directory, 'content', 'loadedvibes.ts'),
+    capabilitiesSource,
+  );
+}
+
+async function writeRoutesContract(
+  directory: string,
+  recipe: NormalizedRecipe,
+): Promise<void> {
+  const publicRoutes = [
+    '/',
+    ...(recipe.modules.marketing ? ['/pricing', '/faq'] : []),
+  ];
+  const protectedRoutes = [
+    '/dashboard',
+    ...(recipe.modules.sampleDomain !== false
+      ? ['/projects', '/projects/new', '/projects/[projectId]']
+      : []),
+    '/settings',
+  ];
+  const apiRoutes = [
+    '/api/clerk/webhooks',
+    '/api/stripe/webhooks',
+    ...(recipe.modules.stripeConnect ? ['/api/stripe/connect/webhooks'] : []),
+  ];
+  const routesContract = `id: vibes.routes
+version: 1
+authority: current-source-contract
+public: ${JSON.stringify(publicRoutes)}
+auth: ["/sign-in", "/sign-up"]
+protected: ${JSON.stringify(protectedRoutes)}
+api: ${JSON.stringify(apiRoutes)}
+reference_catalog:
+  status: production-opt-in
+  route_groups:
+    - app/(presentation)
+    - app/(public)/(presentation)
+    - app/(auth)/(presentation)
+    - app/(tenant)/(presentation)
+  index: /catalog
+  production_gate: PRESENTATION_CATALOG_ENABLED
+  search_metadata: content/presentation/registry.ts
+  robots: noindex,nofollow
+`;
+  await writeFile(
+    path.join(directory, '.agents', 'contracts', 'routes.yaml'),
+    routesContract,
+  );
+}
 
 export async function applyTransforms(plan: GenerationPlan): Promise<void> {
   await rename(
@@ -36,87 +164,8 @@ export async function applyTransforms(plan: GenerationPlan): Promise<void> {
     path.join(plan.stagingDirectory, '.loaded-vibes.json'),
     `${JSON.stringify(provenance, null, 2)}\n`,
   );
-  await writeFile(
-    path.join(plan.stagingDirectory, 'loadedvibes.json'),
-    `${JSON.stringify(plan.config.recipe, null, 2)}\n`,
-  );
-  const capabilitiesSource = `export const loadedVibesProduct = ${JSON.stringify(
-    {
-      name: plan.config.recipe.identity.displayName,
-      description:
-        plan.config.recipe.identity.description ||
-        'A focused SaaS product built with Loaded Vibes.',
-    },
-    null,
-    2,
-  )} as const
-
-export type LoadedVibesDesign = {
-  theme: "obsidian" | "paper" | "electric"
-  radius: "compact" | "medium" | "rounded"
-  density: "compact" | "comfortable"
-  navigation: "sidebar" | "topbar"
-  mode: "light" | "dark" | "system"
-}
-
-export const loadedVibesDesign: LoadedVibesDesign = ${JSON.stringify(
-    plan.config.recipe.design,
-    null,
-    2,
-  )}
-
-export const loadedVibesCapabilities = ${JSON.stringify(
-    {
-      marketing: plan.config.recipe.modules.marketing,
-      sampleDomain: plan.config.recipe.modules.sampleDomain !== false,
-      stripeConnect: plan.config.recipe.modules.stripeConnect,
-    },
-    null,
-    2,
-  )} as const\n`;
-  await writeFile(
-    path.join(plan.stagingDirectory, 'content', 'loadedvibes.ts'),
-    capabilitiesSource,
-  );
-  const publicRoutes = [
-    '/',
-    ...(plan.config.recipe.modules.marketing ? ['/pricing', '/faq'] : []),
-  ];
-  const protectedRoutes = [
-    '/dashboard',
-    ...(plan.config.recipe.modules.sampleDomain !== false
-      ? ['/projects', '/projects/new', '/projects/[projectId]']
-      : []),
-    '/settings',
-  ];
-  const apiRoutes = [
-    '/api/clerk/webhooks',
-    '/api/stripe/webhooks',
-    ...(plan.config.recipe.modules.stripeConnect
-      ? ['/api/stripe/connect/webhooks']
-      : []),
-  ];
-  const routesContract = `id: vibes.routes
-version: 1
-authority: current-source-contract
-public: ${JSON.stringify(publicRoutes)}
-auth: ["/sign-in", "/sign-up"]
-protected: ${JSON.stringify(protectedRoutes)}
-api: ${JSON.stringify(apiRoutes)}
-reference_catalog:
-  status: production-opt-in
-  route_groups:
-    - app/(presentation)
-    - app/(public)/(presentation)
-    - app/(auth)/(presentation)
-    - app/(tenant)/(presentation)
-  index: /catalog
-  production_gate: PRESENTATION_CATALOG_ENABLED
-  search_metadata: content/presentation/registry.ts
-  robots: noindex,nofollow
-`;
-  await writeFile(
-    path.join(plan.stagingDirectory, '.agents', 'contracts', 'routes.yaml'),
-    routesContract,
-  );
+  await writeRecipeArtifacts(plan.stagingDirectory, plan.config.recipe, {
+    templateRevision: String(templateMetadata.templateRevision),
+    sourceRevision: String(templateMetadata.sourceRevision),
+  });
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,10 @@
 export { createProject, type CreateOptions } from './commands/create.js';
+export {
+  applyProjectModuleAddition,
+  planProjectModuleAddition,
+  type ModuleAdditionPlan,
+  type ModuleAdditionResult,
+} from './commands/add.js';
 export { loadConfigFile } from './config/load.js';
 export { normalizeConfig, type ConfigInput } from './config/normalize.js';
 export {
@@ -7,10 +13,17 @@ export {
 } from './config/schema.js';
 export { LoadedVibesError, type LoadedVibesErrorCode } from './errors.js';
 export {
+  generatedModuleIds,
+  selectedGeneratedModuleIds,
   selectGeneratedModules,
   type GeneratedModule,
   type GeneratedModuleId,
 } from './modules.js';
+export {
+  generationManifestSchema,
+  parseGenerationManifest,
+  type GenerationManifest,
+} from './manifest.js';
 export {
   capabilityRegistry,
   resolveCapabilitySelection,

--- a/packages/core/src/manifest.ts
+++ b/packages/core/src/manifest.ts
@@ -1,0 +1,36 @@
+import { z } from 'zod';
+import {
+  normalizedRecipeSchema,
+  productPresetSchema,
+} from '@loaded-vibes/schema';
+import { generatedModuleIds } from './modules.js';
+import { LoadedVibesError } from './errors.js';
+
+export const generationManifestSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    generator: z
+      .object({ name: z.literal('create-loaded-vibes'), version: z.string() })
+      .strict(),
+    template: z
+      .object({ revision: z.string(), sourceRevision: z.string() })
+      .strict(),
+    preset: productPresetSchema,
+    modules: z.array(z.enum(generatedModuleIds)),
+    recipe: normalizedRecipeSchema,
+  })
+  .strict();
+
+export type GenerationManifest = z.infer<typeof generationManifestSchema>;
+
+export function parseGenerationManifest(value: unknown): GenerationManifest {
+  const result = generationManifestSchema.safeParse(value);
+  if (!result.success) {
+    throw new LoadedVibesError(
+      'PROJECT_NOT_GENERATED',
+      'The Loaded Vibes manifest is missing or invalid.',
+      result.error,
+    );
+  }
+  return result.data;
+}

--- a/packages/core/src/modules.ts
+++ b/packages/core/src/modules.ts
@@ -1,10 +1,14 @@
 import path from 'node:path';
 import type { LoadedVibesConfig } from './config/schema.js';
+import type { NormalizedRecipe } from '@loaded-vibes/schema';
 
-export type GeneratedModuleId =
-  | 'marketing'
-  | 'sample-domain'
-  | 'stripe-connect';
+export const generatedModuleIds = [
+  'marketing',
+  'sample-domain',
+  'stripe-connect',
+] as const;
+
+export type GeneratedModuleId = (typeof generatedModuleIds)[number];
 
 export interface GeneratedModule {
   id: GeneratedModuleId;
@@ -16,10 +20,16 @@ export function selectGeneratedModules(
   templateDirectory: string,
 ): GeneratedModule[] {
   const root = path.resolve(templateDirectory, '../modules');
-  const selected: GeneratedModuleId[] = [];
-  if (config.recipe.modules.marketing) selected.push('marketing');
-  if (config.recipe.modules.sampleDomain !== false)
-    selected.push('sample-domain');
-  if (config.recipe.modules.stripeConnect) selected.push('stripe-connect');
+  const selected = selectedGeneratedModuleIds(config.recipe);
   return selected.map((id) => ({ id, sourceDirectory: path.join(root, id) }));
+}
+
+export function selectedGeneratedModuleIds(
+  recipe: NormalizedRecipe,
+): GeneratedModuleId[] {
+  const selected: GeneratedModuleId[] = [];
+  if (recipe.modules.marketing) selected.push('marketing');
+  if (recipe.modules.sampleDomain !== false) selected.push('sample-domain');
+  if (recipe.modules.stripeConnect) selected.push('stripe-connect');
+  return selected;
 }

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -3,6 +3,7 @@ export {
   defaultDesign,
   designSchema,
   moduleSelectionSchema,
+  normalizedRecipeSchema,
   productPresetIds,
   productPresetSchema,
   productIdentitySchema,

--- a/packages/schema/src/recipe.ts
+++ b/packages/schema/src/recipe.ts
@@ -88,6 +88,13 @@ export const recipeSchema = z
   })
   .strict();
 
+export const normalizedRecipeSchema = recipeSchema.extend({
+  modules: resolvedModulesSchema,
+  identity: productIdentitySchema.extend({
+    displayName: z.string().trim().min(1),
+  }),
+});
+
 export type RecipeInput = z.input<typeof recipeSchema>;
 export type ParsedRecipe = z.output<typeof recipeSchema>;
 export type ProductPresetId = z.infer<typeof productPresetSchema>;
@@ -101,11 +108,4 @@ export type ProductIdentity = z.output<typeof productIdentitySchema> & {
 export type DesignInput = z.input<typeof designSchema>;
 export type Design = z.output<typeof designSchema>;
 
-export interface NormalizedRecipe {
-  schemaVersion: typeof recipeSchemaVersion;
-  name: string;
-  product: ProductPresetId;
-  modules: ResolvedModules;
-  identity: ProductIdentity;
-  design: Design;
-}
+export type NormalizedRecipe = z.infer<typeof normalizedRecipeSchema>;

--- a/templates/modules/marketing/.loaded-vibes-module.json
+++ b/templates/modules/marketing/.loaded-vibes-module.json
@@ -3,6 +3,12 @@
   "id": "marketing",
   "requires": [],
   "conflicts": [],
-  "contributions": ["app/(public)/pricing", "app/(public)/faq", "tests/e2e/public-routes.spec.ts"],
+  "replaces": [],
+  "setup": [],
+  "contributions": [
+    "app/(public)/pricing",
+    "app/(public)/faq",
+    "tests/e2e/public-routes.spec.ts"
+  ],
   "sourceRevision": "19e20084a8c69cc5a70f8db5f8e5d908a84d582f"
 }

--- a/templates/modules/sample-domain/.loaded-vibes-module.json
+++ b/templates/modules/sample-domain/.loaded-vibes-module.json
@@ -3,6 +3,8 @@
   "id": "sample-domain",
   "requires": ["organizations", "rbac"],
   "conflicts": [],
+  "replaces": ["features/dashboard/dashboard-feature.tsx"],
+  "setup": [],
   "contributions": [
     "app/(tenant)/projects",
     "features/dashboard/dashboard-feature.tsx",

--- a/templates/modules/stripe-connect/.loaded-vibes-module.json
+++ b/templates/modules/stripe-connect/.loaded-vibes-module.json
@@ -3,6 +3,11 @@
   "id": "stripe-connect",
   "requires": ["organizations", "rbac", "billing"],
   "conflicts": [],
+  "replaces": [],
+  "setup": [
+    "Configure STRIPE_CONNECT_WEBHOOK_SECRET.",
+    "Register /api/stripe/connect/webhooks in Stripe before enabling live traffic."
+  ],
   "contributions": [
     "app/api/stripe/connect",
     "lib/connect",

--- a/tests/generated/real-cli.test.ts
+++ b/tests/generated/real-cli.test.ts
@@ -119,4 +119,30 @@ describe('real user-facing CLI', () => {
     }
     expect(await snapshot(targets[0]!)).toEqual(await snapshot(targets[1]!));
   }, 15_000);
+
+  it('adds a supported module through the real CLI', async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), 'loaded-vibes-add-cli-'));
+    const target = path.join(root, 'add-app');
+    await execa('node', [
+      cli,
+      target,
+      '--name',
+      'add-app',
+      '--yes',
+      '--no-git',
+      '--skip-install',
+    ]);
+    const result = await execa('node', [
+      cli,
+      'add',
+      'marketing',
+      '--cwd',
+      target,
+    ]);
+    expect(result.stdout).toContain('Module: marketing');
+    expect(result.stdout).toContain('Capabilities: marketing');
+    await expect(
+      stat(path.join(target, 'app', '(public)', 'pricing', 'page.tsx')),
+    ).resolves.toBeTruthy();
+  }, 15_000);
 });

--- a/tests/integration/add-module.test.ts
+++ b/tests/integration/add-module.test.ts
@@ -1,0 +1,86 @@
+import { mkdtemp, readFile, stat, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  applyProjectModuleAddition,
+  createProject,
+  planProjectModuleAddition,
+} from '@loaded-vibes/core';
+
+async function createBareProject(prefix: string): Promise<string> {
+  const root = await mkdtemp(path.join(os.tmpdir(), prefix));
+  const target = path.join(root, 'app');
+  await createProject({
+    name: 'module-test-app',
+    product: 'bare-golden-app',
+    targetDirectory: target,
+    git: { initialize: false },
+    install: { enabled: false },
+  });
+  return target;
+}
+
+describe('post-generation module addition', () => {
+  it('records a manifest and adds a supported module with updated provenance', async () => {
+    const target = await createBareProject('loaded-vibes-add-marketing-');
+    const initialManifest = JSON.parse(
+      await readFile(
+        path.join(target, '.loadedvibes', 'manifest.json'),
+        'utf8',
+      ),
+    ) as { modules: string[] };
+    expect(initialManifest.modules).toEqual([]);
+
+    const plan = await planProjectModuleAddition(target, 'marketing');
+    expect(plan.addedCapabilities).toEqual(['marketing']);
+    expect(plan.prerequisites).toEqual([]);
+    const result = await applyProjectModuleAddition(plan);
+    expect(result.filesAdded.length).toBeGreaterThan(0);
+    await expect(
+      stat(path.join(target, 'app', '(public)', 'pricing', 'page.tsx')),
+    ).resolves.toBeTruthy();
+    const updatedManifest = JSON.parse(
+      await readFile(
+        path.join(target, '.loadedvibes', 'manifest.json'),
+        'utf8',
+      ),
+    ) as { modules: string[]; recipe: { modules: { marketing: boolean } } };
+    expect(updatedManifest.modules).toEqual(['marketing']);
+    expect(updatedManifest.recipe.modules.marketing).toBe(true);
+    await expect(
+      readFile(
+        path.join(target, '.agents', 'contracts', 'routes.yaml'),
+        'utf8',
+      ),
+    ).resolves.toContain('/pricing');
+  });
+
+  it('resolves capability prerequisites and reports setup before applying', async () => {
+    const target = await createBareProject('loaded-vibes-add-connect-');
+    const plan = await planProjectModuleAddition(target, 'stripe-connect');
+    expect(plan.addedCapabilities).toEqual(['billing', 'stripeConnect']);
+    expect(plan.prerequisites).toEqual(['billing']);
+    expect(plan.setup.join(' ')).toContain('STRIPE_CONNECT_WEBHOOK_SECRET');
+    expect(plan.files).toContain(
+      path.join('app', 'api', 'stripe', 'connect', 'webhooks', 'route.ts'),
+    );
+  });
+
+  it('refuses to overwrite a user-modified intentional replacement', async () => {
+    const target = await createBareProject('loaded-vibes-add-conflict-');
+    const dashboard = path.join(
+      target,
+      'features',
+      'dashboard',
+      'dashboard-feature.tsx',
+    );
+    await writeFile(dashboard, '// user-owned dashboard\n');
+    await expect(
+      planProjectModuleAddition(target, 'sample-domain'),
+    ).rejects.toMatchObject({ code: 'MODULE_CONFLICT' });
+    await expect(readFile(dashboard, 'utf8')).resolves.toBe(
+      '// user-owned dashboard\n',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- generate a versioned .loadedvibes/manifest.json with recipe, module, template, and generator provenance
- add the loaded-vibes add command for marketing, sample-domain, and stripe-connect
- resolve capability prerequisites and report files, replacements, and setup before mutation
- reject unsupported modules, metadata drift, existing modules, and user-modified collisions

## QA
- corepack pnpm exec vitest run tests/unit/config.test.ts tests/unit/recipe-resolution.test.ts tests/integration/add-module.test.ts tests/integration/materialize.test.ts (21 passed)
- corepack pnpm typecheck
- corepack pnpm lint
- corepack pnpm format:check
- corepack pnpm test:generated (6 passed, including real CLI add)
- corepack pnpm pack:check (345 safe entries)

## Safety
- only packaged repository-owned modules are accepted
- declared replacement files must still byte-match the golden baseline
- this does not implement arbitrary template upgrades or source merging

Closes #97