### PR TITLE
feat(cli): add doctor and explain commands

### DIFF
--- a/.agents/execution/decisions.json
+++ b/.agents/execution/decisions.json
@@ -38,6 +38,12 @@
       "decision": "Post-generation add is limited to packaged repository modules, preflights every file, and permits declared replacements only while the destination still matches the golden baseline.",
       "status": "active",
       "issue": 97
+    },
+    {
+      "id": "LV-D-008",
+      "decision": "Doctor performs only local metadata, dependency, Prisma-client, and non-secret environment-shape checks; explain derives product meaning and remaining setup from the manifest and recipe.",
+      "status": "active",
+      "issue": 98
     }
   ]
 }

--- a/.agents/execution/handoff.json
+++ b/.agents/execution/handoff.json
@@ -1,20 +1,19 @@
 {
   "schemaVersion": 2,
   "status": "in-progress",
-  "currentOutcome": "LV-106 generation manifest and safe post-generation module addition implemented on feature/97-post-generation-add.",
-  "activeIssue": 97,
-  "activeBranch": "feature/97-post-generation-add",
-  "activePullRequest": "https://github.com/DigitalHerencia/LoadedVibes/pull/107",
-  "lastCompletedIssue": 96,
-  "lastMergedPullRequest": "https://github.com/DigitalHerencia/LoadedVibes/pull/106",
-  "nextAction": "Open and review the Issue #97 pull request, then merge when its acceptance criteria remain satisfied.",
+  "currentOutcome": "LV-107 actionable doctor diagnostics and manifest-backed explain output implemented on feature/98-doctor-explain.",
+  "activeIssue": 98,
+  "activeBranch": "feature/98-doctor-explain",
+  "activePullRequest": null,
+  "lastCompletedIssue": 97,
+  "lastMergedPullRequest": "https://github.com/DigitalHerencia/LoadedVibes/pull/107",
+  "nextAction": "Open and review the Issue #98 pull request, then merge when its acceptance criteria remain satisfied.",
   "executedEvidence": [
-    "corepack pnpm exec vitest run tests/unit/config.test.ts tests/unit/recipe-resolution.test.ts tests/integration/add-module.test.ts tests/integration/materialize.test.ts (21 tests passed)",
+    "corepack pnpm exec vitest run tests/integration/diagnostics.test.ts tests/integration/add-module.test.ts (6 tests passed)",
     "corepack pnpm typecheck",
     "corepack pnpm lint",
     "corepack pnpm format:check",
-    "corepack pnpm test:generated (6 tests passed)",
-    "corepack pnpm pack:check (345 safe entries)"
+    "corepack pnpm test:generated (7 tests passed)"
   ],
   "blockedEvidence": [],
   "notes": [

--- a/.agents/execution/handoff.json
+++ b/.agents/execution/handoff.json
@@ -4,7 +4,7 @@
   "currentOutcome": "LV-107 actionable doctor diagnostics and manifest-backed explain output implemented on feature/98-doctor-explain.",
   "activeIssue": 98,
   "activeBranch": "feature/98-doctor-explain",
-  "activePullRequest": null,
+  "activePullRequest": "https://github.com/DigitalHerencia/LoadedVibes/pull/108",
   "lastCompletedIssue": 97,
   "lastMergedPullRequest": "https://github.com/DigitalHerencia/LoadedVibes/pull/107",
   "nextAction": "Open and review the Issue #98 pull request, then merge when its acceptance criteria remain satisfied.",

--- a/.agents/execution/progress.json
+++ b/.agents/execution/progress.json
@@ -118,7 +118,7 @@
       "issue": 98,
       "status": "implemented",
       "branch": "feature/98-doctor-explain",
-      "pullRequest": null,
+      "pullRequest": "https://github.com/DigitalHerencia/LoadedVibes/pull/108",
       "evidence": {
         "executed": [
           "corepack pnpm exec vitest run tests/integration/diagnostics.test.ts tests/integration/add-module.test.ts (6 tests passed)",

--- a/.agents/execution/progress.json
+++ b/.agents/execution/progress.json
@@ -2,9 +2,9 @@
   "schemaVersion": 2,
   "roadmap": "generator-product-roadmap",
   "status": "in_progress",
-  "activeIssue": 97,
-  "activeBranch": "feature/97-post-generation-add",
-  "completed": [92, 93, 94, 95, 96],
+  "activeIssue": 98,
+  "activeBranch": "feature/98-doctor-explain",
+  "completed": [92, 93, 94, 95, 96, 97],
   "workItems": [
     {
       "id": "LV-101",
@@ -98,7 +98,7 @@
     {
       "id": "LV-106",
       "issue": 97,
-      "status": "implemented",
+      "status": "verified",
       "branch": "feature/97-post-generation-add",
       "pullRequest": "https://github.com/DigitalHerencia/LoadedVibes/pull/107",
       "evidence": {
@@ -109,6 +109,23 @@
           "corepack pnpm format:check",
           "corepack pnpm test:generated (6 tests passed)",
           "corepack pnpm pack:check (345 safe entries)"
+        ],
+        "blocked": []
+      }
+    },
+    {
+      "id": "LV-107",
+      "issue": 98,
+      "status": "implemented",
+      "branch": "feature/98-doctor-explain",
+      "pullRequest": null,
+      "evidence": {
+        "executed": [
+          "corepack pnpm exec vitest run tests/integration/diagnostics.test.ts tests/integration/add-module.test.ts (6 tests passed)",
+          "corepack pnpm typecheck",
+          "corepack pnpm lint",
+          "corepack pnpm format:check",
+          "corepack pnpm test:generated (7 tests passed)"
         ],
         "blocked": []
       }

--- a/README.md
+++ b/README.md
@@ -26,4 +26,6 @@ loaded-vibes add stripe-connect
 
 The command resolves capability prerequisites, previews files and setup, and refuses user-modified collisions. It does not merge arbitrary template upgrades.
 
+Use `loaded-vibes doctor` inside a generated project for concise local and provider-readiness actions. Use `loaded-vibes explain` to review the preset, capabilities, packaged modules, design, provider boundaries, architecture, and remaining setup recorded by the recipe and manifest. Neither command runs the project validation matrix.
+
 The canonical product and architecture sources live in [`context/`](context/README.md). Machine contracts and execution evidence live in [`.agents/`](.agents/AGENTS.md).

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -4,6 +4,8 @@ import { cancel, intro, isCancel, outro, spinner, text } from '@clack/prompts';
 import {
   applyProjectModuleAddition,
   createProject,
+  diagnoseProject,
+  explainProject,
   loadConfigFile,
   LoadedVibesError,
   planProjectModuleAddition,
@@ -162,6 +164,56 @@ program
     outro(
       `${result.filesAdded.length} files added, ${result.filesReplaced.length} updated. ${result.setup.join(' ')}`.trim(),
     );
+  });
+
+program
+  .command('doctor')
+  .description('Diagnose generated-project readiness and configuration.')
+  .option('--cwd <directory>', 'generated project directory', '.')
+  .action(async (flags: { cwd: string }) => {
+    intro('Loaded Vibes doctor');
+    const result = await diagnoseProject(flags.cwd);
+    for (const check of result.checks) {
+      const mark = check.status === 'pass' ? '✓' : '✗';
+      console.log(`${mark} ${check.label}: ${check.message}`);
+      if (check.action) console.log(`  ${check.action}`);
+    }
+    if (result.ok) outro('Project prerequisites are ready.');
+    else {
+      outro('Complete the actions above, then rerun loaded-vibes doctor.');
+      process.exitCode = 1;
+    }
+  });
+
+program
+  .command('explain')
+  .description('Explain a generated project and its remaining setup.')
+  .option('--cwd <directory>', 'generated project directory', '.')
+  .action(async (flags: { cwd: string }) => {
+    intro('Loaded Vibes explain');
+    const explanation = await explainProject(flags.cwd);
+    console.log(
+      [
+        explanation.product,
+        '',
+        `Preset: ${explanation.preset.label} (${explanation.preset.id})`,
+        `Capabilities: ${explanation.capabilities.join(', ')}`,
+        `Packaged modules: ${explanation.modules.join(', ') || 'none'}`,
+        `Design: ${explanation.design.join(', ')}`,
+        '',
+        'Provider boundaries',
+        ...explanation.providers.map((provider) => `  - ${provider}`),
+        '',
+        'Architecture',
+        ...explanation.architecture.map((rule) => `  - ${rule}`),
+        '',
+        'Remaining setup',
+        ...(explanation.remainingSetup.length
+          ? explanation.remainingSetup.map((item) => `  - ${item}`)
+          : ['  - none']),
+      ].join('\n'),
+    );
+    outro('Explanation complete.');
   });
 
 program.parseAsync().catch((error: unknown) => {

--- a/packages/core/src/commands/doctor.ts
+++ b/packages/core/src/commands/doctor.ts
@@ -1,0 +1,261 @@
+import { access, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import type { NormalizedRecipe } from '@loaded-vibes/schema';
+import { loadGeneratedProject } from '../project.js';
+
+export type DiagnosticStatus = 'pass' | 'fail';
+export type DiagnosticOwner = 'local' | 'user-setup' | 'generator';
+
+export interface DiagnosticCheck {
+  id: string;
+  label: string;
+  status: DiagnosticStatus;
+  owner: DiagnosticOwner;
+  message: string;
+  action?: string;
+}
+
+export interface DoctorResult {
+  directory: string;
+  ok: boolean;
+  checks: DiagnosticCheck[];
+}
+
+interface EnvRequirement {
+  name: string;
+  hint: string;
+  valid?: (value: string) => boolean;
+}
+
+async function exists(file: string): Promise<boolean> {
+  try {
+    await access(file);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readEnvironment(
+  directory: string,
+): Promise<Map<string, string>> {
+  const values = new Map<string, string>();
+  for (const file of ['.env', '.env.local']) {
+    try {
+      const body = await readFile(path.join(directory, file), 'utf8');
+      for (const line of body.split(/\r?\n/)) {
+        const match = line.match(
+          /^\s*(?:export\s+)?([A-Z][A-Z0-9_]*)\s*=\s*(.*)\s*$/,
+        );
+        if (!match?.[1] || match[2] === undefined) continue;
+        values.set(match[1], match[2].replace(/^['"]|['"]$/g, '').trim());
+      }
+    } catch {
+      // Missing local environment files are reported as individual setup checks.
+    }
+  }
+  return values;
+}
+
+function envRequirements(recipe: NormalizedRecipe): EnvRequirement[] {
+  const requirements: EnvRequirement[] = [
+    {
+      name: 'DATABASE_URL',
+      hint: 'Set the pooled Neon runtime URL in .env.local.',
+      valid: (value) =>
+        value.startsWith('postgresql://') && value.includes('-pooler'),
+    },
+    {
+      name: 'DIRECT_DATABASE_URL',
+      hint: 'Set the direct Neon migration URL in .env.local.',
+      valid: (value) =>
+        value.startsWith('postgresql://') && !value.includes('-pooler'),
+    },
+    {
+      name: 'NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY',
+      hint: 'Add the Clerk publishable key to .env.local.',
+      valid: (value) => value.startsWith('pk_'),
+    },
+    {
+      name: 'CLERK_SECRET_KEY',
+      hint: 'Add the Clerk secret key to .env.local.',
+      valid: (value) => value.startsWith('sk_'),
+    },
+    {
+      name: 'CLERK_WEBHOOK_SIGNING_SECRET',
+      hint: 'Create the Clerk webhook and add its whsec_ secret to .env.local.',
+      valid: (value) => value.startsWith('whsec_'),
+    },
+  ];
+  if (recipe.modules.billing) {
+    requirements.push(
+      {
+        name: 'STRIPE_SECRET_KEY',
+        hint: 'Add the Stripe secret key to .env.local.',
+        valid: (value) => value.startsWith('sk_'),
+      },
+      {
+        name: 'STRIPE_WEBHOOK_SECRET',
+        hint: 'Create the Stripe subscription webhook and add its whsec_ secret.',
+        valid: (value) => value.startsWith('whsec_'),
+      },
+      {
+        name: 'STRIPE_RECURRING_PRICE_ID',
+        hint: 'Create a recurring Stripe Price and add its price_ ID.',
+        valid: (value) => value.startsWith('price_'),
+      },
+    );
+  }
+  if (recipe.modules.stripeConnect) {
+    requirements.push({
+      name: 'STRIPE_CONNECT_WEBHOOK_SECRET',
+      hint: 'Register the Connect webhook and add its whsec_ secret.',
+      valid: (value) => value.startsWith('whsec_'),
+    });
+  }
+  return requirements;
+}
+
+export async function diagnoseProject(directory = '.'): Promise<DoctorResult> {
+  const target = path.resolve(directory);
+  const checks: DiagnosticCheck[] = [];
+  const nodeMajor = Number(process.versions.node.split('.')[0]);
+  checks.push(
+    nodeMajor >= 24
+      ? {
+          id: 'node',
+          label: 'Node.js',
+          status: 'pass',
+          owner: 'local',
+          message: `Node ${process.versions.node}`,
+        }
+      : {
+          id: 'node',
+          label: 'Node.js',
+          status: 'fail',
+          owner: 'local',
+          message: `Node ${process.versions.node} is unsupported.`,
+          action: 'Install Node.js 24 and rerun loaded-vibes doctor.',
+        },
+  );
+
+  let recipe: NormalizedRecipe | undefined;
+  try {
+    const project = await loadGeneratedProject(target);
+    recipe = project.recipe;
+    checks.push({
+      id: 'recipe-manifest',
+      label: 'Recipe and manifest',
+      status: 'pass',
+      owner: 'generator',
+      message: `Schema v${project.manifest.schemaVersion}; ${project.manifest.modules.length} packaged modules.`,
+    });
+  } catch (error) {
+    checks.push({
+      id: 'recipe-manifest',
+      label: 'Recipe and manifest',
+      status: 'fail',
+      owner: 'generator',
+      message: error instanceof Error ? error.message : String(error),
+      action: 'Run this command from an intact Loaded Vibes generated project.',
+    });
+  }
+
+  const packageManagerReady =
+    (await exists(path.join(target, 'package.json'))) &&
+    (await exists(path.join(target, 'pnpm-lock.yaml')));
+  checks.push(
+    packageManagerReady
+      ? {
+          id: 'package-manager',
+          label: 'Package manager',
+          status: 'pass',
+          owner: 'local',
+          message: 'pnpm project metadata is present.',
+        }
+      : {
+          id: 'package-manager',
+          label: 'Package manager',
+          status: 'fail',
+          owner: 'generator',
+          message: 'package.json or pnpm-lock.yaml is missing.',
+          action: 'Restore the generated package files before continuing.',
+        },
+  );
+
+  const dependenciesReady = await exists(path.join(target, 'node_modules'));
+  checks.push(
+    dependenciesReady
+      ? {
+          id: 'dependencies',
+          label: 'Dependencies',
+          status: 'pass',
+          owner: 'local',
+          message: 'node_modules is present.',
+        }
+      : {
+          id: 'dependencies',
+          label: 'Dependencies',
+          status: 'fail',
+          owner: 'local',
+          message: 'Dependencies are not installed.',
+          action: 'Run corepack pnpm install.',
+        },
+  );
+
+  const prismaReady = await exists(
+    path.join(target, 'prisma', 'generated', 'prisma', 'client.ts'),
+  );
+  checks.push(
+    prismaReady
+      ? {
+          id: 'prisma-client',
+          label: 'Prisma client',
+          status: 'pass',
+          owner: 'local',
+          message: 'Generated Prisma client is present.',
+        }
+      : {
+          id: 'prisma-client',
+          label: 'Prisma client',
+          status: 'fail',
+          owner: 'local',
+          message: 'Generated Prisma client is missing.',
+          action: 'Run corepack pnpm db:generate.',
+        },
+  );
+
+  if (recipe) {
+    const environment = await readEnvironment(target);
+    for (const requirement of envRequirements(recipe)) {
+      const value = environment.get(requirement.name) ?? '';
+      const valid = value.length > 0 && (requirement.valid?.(value) ?? true);
+      checks.push(
+        valid
+          ? {
+              id: `env:${requirement.name}`,
+              label: requirement.name,
+              status: 'pass',
+              owner: 'user-setup',
+              message: 'Configured with the expected shape.',
+            }
+          : {
+              id: `env:${requirement.name}`,
+              label: requirement.name,
+              status: 'fail',
+              owner: 'user-setup',
+              message: value
+                ? 'Configured value has an unexpected shape.'
+                : 'Missing.',
+              action: requirement.hint,
+            },
+      );
+    }
+  }
+
+  return {
+    directory: target,
+    ok: checks.every((check) => check.status === 'pass'),
+    checks,
+  };
+}

--- a/packages/core/src/commands/explain.ts
+++ b/packages/core/src/commands/explain.ts
@@ -1,0 +1,67 @@
+import { capabilityIds, type CapabilityId } from '@loaded-vibes/schema';
+import { capabilityRegistry } from '../capabilities.js';
+import { getProductPreset } from '@loaded-vibes/recipes';
+import { loadGeneratedProject } from '../project.js';
+import { diagnoseProject } from './doctor.js';
+
+export interface ProjectExplanation {
+  product: string;
+  preset: { id: string; label: string };
+  capabilities: string[];
+  modules: string[];
+  design: string[];
+  providers: string[];
+  architecture: string[];
+  remainingSetup: string[];
+}
+
+function enabled(
+  modules: Awaited<
+    ReturnType<typeof loadGeneratedProject>
+  >['recipe']['modules'],
+  id: CapabilityId,
+): boolean {
+  return id === 'sampleDomain' ? modules.sampleDomain !== false : modules[id];
+}
+
+export async function explainProject(
+  directory = '.',
+): Promise<ProjectExplanation> {
+  const project = await loadGeneratedProject(directory);
+  const doctor = await diagnoseProject(project.directory);
+  const preset = getProductPreset(project.recipe.product);
+  const providers = [
+    'Clerk owns identity and sessions; application rows own authorization.',
+    'Neon/PostgreSQL owns persistence; Prisma is the typed data client.',
+  ];
+  if (project.recipe.modules.billing)
+    providers.push(
+      'Stripe owns subscription payment truth and webhook events.',
+    );
+  if (project.recipe.modules.stripeConnect)
+    providers.push('Stripe Connect owns connected-account and transfer truth.');
+  return {
+    product: project.recipe.identity.displayName,
+    preset: { id: preset.id, label: preset.label },
+    capabilities: capabilityIds
+      .filter((id) => enabled(project.recipe.modules, id))
+      .map((id) => capabilityRegistry[id].label),
+    modules: project.manifest.modules,
+    design: [
+      project.recipe.design.theme,
+      project.recipe.design.mode,
+      project.recipe.design.radius,
+      project.recipe.design.density,
+      project.recipe.design.navigation,
+    ],
+    providers,
+    architecture: [
+      'Routes adapt; features orchestrate; components render.',
+      'Fetchers read; Server Actions write; schemas validate.',
+      'Authorization decides; transactions preserve invariants; webhooks reconcile provider truth.',
+    ],
+    remainingSetup: doctor.checks
+      .filter((check) => check.status === 'fail' && check.action)
+      .map((check) => `${check.label}: ${check.action}`),
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,6 +5,14 @@ export {
   type ModuleAdditionPlan,
   type ModuleAdditionResult,
 } from './commands/add.js';
+export {
+  diagnoseProject,
+  type DiagnosticCheck,
+  type DiagnosticOwner,
+  type DiagnosticStatus,
+  type DoctorResult,
+} from './commands/doctor.js';
+export { explainProject, type ProjectExplanation } from './commands/explain.js';
 export { loadConfigFile } from './config/load.js';
 export { normalizeConfig, type ConfigInput } from './config/normalize.js';
 export {
@@ -24,6 +32,7 @@ export {
   parseGenerationManifest,
   type GenerationManifest,
 } from './manifest.js';
+export { loadGeneratedProject, type GeneratedProject } from './project.js';
 export {
   capabilityRegistry,
   resolveCapabilitySelection,

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -1,0 +1,46 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import type { NormalizedRecipe } from '@loaded-vibes/schema';
+import { LoadedVibesError } from './errors.js';
+import {
+  parseGenerationManifest,
+  type GenerationManifest,
+} from './manifest.js';
+import { resolveRecipe } from './recipe.js';
+
+export interface GeneratedProject {
+  directory: string;
+  manifest: GenerationManifest;
+  recipe: NormalizedRecipe;
+}
+
+async function readJson(file: string): Promise<unknown> {
+  try {
+    return JSON.parse(await readFile(file, 'utf8')) as unknown;
+  } catch (error) {
+    throw new LoadedVibesError(
+      'PROJECT_NOT_GENERATED',
+      `Unable to read generated project metadata at ${file}.`,
+      error,
+    );
+  }
+}
+
+export async function loadGeneratedProject(
+  directory: string,
+): Promise<GeneratedProject> {
+  const target = path.resolve(directory);
+  const manifest = parseGenerationManifest(
+    await readJson(path.join(target, '.loadedvibes', 'manifest.json')),
+  );
+  const recipe = resolveRecipe(
+    (await readJson(path.join(target, 'loadedvibes.json'))) as NormalizedRecipe,
+  ).recipe;
+  if (JSON.stringify(manifest.recipe) !== JSON.stringify(recipe)) {
+    throw new LoadedVibesError(
+      'MODULE_CONFLICT',
+      'loadedvibes.json and .loadedvibes/manifest.json disagree.',
+    );
+  }
+  return { directory: target, manifest, recipe };
+}

--- a/tests/generated/real-cli.test.ts
+++ b/tests/generated/real-cli.test.ts
@@ -145,4 +145,30 @@ describe('real user-facing CLI', () => {
       stat(path.join(target, 'app', '(public)', 'pricing', 'page.tsx')),
     ).resolves.toBeTruthy();
   }, 15_000);
+
+  it('diagnoses and explains a generated project without running validation suites', async () => {
+    const root = await mkdtemp(
+      path.join(os.tmpdir(), 'loaded-vibes-diagnostics-cli-'),
+    );
+    const target = path.join(root, 'diagnostic-app');
+    await execa('node', [
+      cli,
+      target,
+      '--name',
+      'diagnostic-app',
+      '--yes',
+      '--no-git',
+      '--skip-install',
+    ]);
+    const doctor = await execa('node', [cli, 'doctor', '--cwd', target], {
+      reject: false,
+    });
+    expect(doctor.exitCode).toBe(1);
+    expect(doctor.stdout).toContain('Run corepack pnpm install.');
+    expect(doctor.stdout).toContain('Add the Clerk secret key to .env.local.');
+    const explain = await execa('node', [cli, 'explain', '--cwd', target]);
+    expect(explain.stdout).toContain('Preset: Bare golden app');
+    expect(explain.stdout).toContain('Provider boundaries');
+    expect(explain.stdout).toContain('Remaining setup');
+  }, 15_000);
 });

--- a/tests/integration/diagnostics.test.ts
+++ b/tests/integration/diagnostics.test.ts
@@ -1,0 +1,95 @@
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  createProject,
+  diagnoseProject,
+  explainProject,
+} from '@loaded-vibes/core';
+
+async function generatedProject(): Promise<string> {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'loaded-vibes-doctor-'));
+  const target = path.join(root, 'app');
+  await createProject({
+    name: 'diagnostic-app',
+    product: 'bare-golden-app',
+    identity: { displayName: 'Diagnostic App' },
+    targetDirectory: target,
+    git: { initialize: false },
+    install: { enabled: false },
+  });
+  return target;
+}
+
+describe('doctor and explain', () => {
+  it('reports missing local and provider setup with exact actions', async () => {
+    const target = await generatedProject();
+    const result = await diagnoseProject(target);
+    expect(result.ok).toBe(false);
+    expect(result.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'dependencies',
+          status: 'fail',
+          action: 'Run corepack pnpm install.',
+        }),
+        expect.objectContaining({
+          id: 'prisma-client',
+          status: 'fail',
+          action: 'Run corepack pnpm db:generate.',
+        }),
+        expect.objectContaining({
+          id: 'env:CLERK_SECRET_KEY',
+          owner: 'user-setup',
+          status: 'fail',
+        }),
+      ]),
+    );
+  });
+
+  it('passes bounded readiness checks when prerequisites are present', async () => {
+    const target = await generatedProject();
+    await mkdir(path.join(target, 'node_modules'));
+    await mkdir(path.join(target, 'prisma', 'generated', 'prisma'), {
+      recursive: true,
+    });
+    await writeFile(
+      path.join(target, 'prisma', 'generated', 'prisma', 'client.ts'),
+      'export {}\n',
+    );
+    await writeFile(
+      path.join(target, '.env.local'),
+      [
+        'DATABASE_URL="postgresql://user:pass@demo-pooler.neon.tech/app"',
+        'DIRECT_DATABASE_URL="postgresql://owner:pass@demo.neon.tech/app"',
+        'NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY="pk_test_example"',
+        'CLERK_SECRET_KEY="sk_test_example"',
+        'CLERK_WEBHOOK_SIGNING_SECRET="whsec_example"',
+      ].join('\n'),
+    );
+    await expect(diagnoseProject(target)).resolves.toMatchObject({ ok: true });
+  });
+
+  it('explains recipe capabilities, design, boundaries, and remaining setup', async () => {
+    const target = await generatedProject();
+    const explanation = await explainProject(target);
+    expect(explanation).toMatchObject({
+      product: 'Diagnostic App',
+      preset: { id: 'bare-golden-app', label: 'Bare golden app' },
+      modules: [],
+      design: ['obsidian', 'system', 'medium', 'comfortable', 'sidebar'],
+    });
+    expect(explanation.capabilities).toEqual(
+      expect.arrayContaining([
+        'Organizations',
+        'Local roles and authorization',
+        'Generated project guidance',
+      ]),
+    );
+    expect(explanation.providers.join(' ')).toContain('Clerk owns identity');
+    expect(explanation.remainingSetup.join(' ')).toContain(
+      'Run corepack pnpm install.',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add bounded doctor checks for Node, project metadata, pnpm files, dependencies, Prisma generation, and capability-aware env shapes
- provide exact remediation without exposing configured values
- add explain output for preset, capabilities, modules, design, provider boundaries, architecture, and remaining setup
- share generated-project loading between manifest-backed inspection commands

## QA
- corepack pnpm exec vitest run tests/integration/diagnostics.test.ts tests/integration/add-module.test.ts (6 passed)
- corepack pnpm typecheck
- corepack pnpm lint
- corepack pnpm format:check
- corepack pnpm test:generated (7 passed, including real doctor/explain CLI)

## Scope notes
- doctor reads local files only and does not run repository validation, builds, providers, or deployments
- explain reads recipe/manifest state and uses doctor only for bounded remaining-setup checks

Closes #98