### PR TITLE
feat(web): add live preview and CLI handoff

### DIFF
--- a/.agents/execution/decisions.json
+++ b/.agents/execution/decisions.json
@@ -50,6 +50,12 @@
       "decision": "The stateless configurator imports the browser-safe shared recipe resolver, persists no server data, and exports the same normalized loadedvibes.json contract consumed by the CLI.",
       "status": "active",
       "issue": 99
+    },
+    {
+      "id": "LV-D-010",
+      "decision": "Web previews are representative Vibes-aligned surface mockups bound to normalized recipe fields; unsupported capability surfaces are labeled as excluded instead of simulated as working product behavior.",
+      "status": "active",
+      "issue": 100
     }
   ]
 }

--- a/.agents/execution/handoff.json
+++ b/.agents/execution/handoff.json
@@ -4,7 +4,7 @@
   "currentOutcome": "LV-109 representative live preview and recipe-to-CLI handoff implemented on feature/100-live-preview-handoff.",
   "activeIssue": 100,
   "activeBranch": "feature/100-live-preview-handoff",
-  "activePullRequest": null,
+  "activePullRequest": "https://github.com/DigitalHerencia/LoadedVibes/pull/110",
   "lastCompletedIssue": 99,
   "lastMergedPullRequest": "https://github.com/DigitalHerencia/LoadedVibes/pull/109",
   "nextAction": "Open and review the Issue #100 pull request, then merge when its acceptance criteria remain satisfied.",

--- a/.agents/execution/handoff.json
+++ b/.agents/execution/handoff.json
@@ -1,19 +1,18 @@
 {
   "schemaVersion": 2,
   "status": "in-progress",
-  "currentOutcome": "LV-108 stateless visual recipe configurator implemented on feature/99-web-configurator.",
-  "activeIssue": 99,
-  "activeBranch": "feature/99-web-configurator",
-  "activePullRequest": "https://github.com/DigitalHerencia/LoadedVibes/pull/109",
-  "lastCompletedIssue": 98,
-  "lastMergedPullRequest": "https://github.com/DigitalHerencia/LoadedVibes/pull/108",
-  "nextAction": "Open and review the Issue #99 pull request, then merge when its acceptance criteria remain satisfied.",
+  "currentOutcome": "LV-109 representative live preview and recipe-to-CLI handoff implemented on feature/100-live-preview-handoff.",
+  "activeIssue": 100,
+  "activeBranch": "feature/100-live-preview-handoff",
+  "activePullRequest": null,
+  "lastCompletedIssue": 99,
+  "lastMergedPullRequest": "https://github.com/DigitalHerencia/LoadedVibes/pull/109",
+  "nextAction": "Open and review the Issue #100 pull request, then merge when its acceptance criteria remain satisfied.",
   "executedEvidence": [
-    "corepack pnpm exec vitest run tests/unit/web-configurator.test.ts (4 tests passed)",
+    "corepack pnpm exec vitest run tests/unit/web-configurator.test.ts (5 tests passed)",
     "corepack pnpm --dir apps/web typecheck",
     "corepack pnpm lint",
-    "corepack pnpm web:build (static route generated)",
-    "corepack pnpm validate (34 unit/integration tests and 7 generated CLI tests passed)"
+    "corepack pnpm web:build (static route generated)"
   ],
   "blockedEvidence": [],
   "notes": [

--- a/.agents/execution/progress.json
+++ b/.agents/execution/progress.json
@@ -152,7 +152,7 @@
       "issue": 100,
       "status": "implemented",
       "branch": "feature/100-live-preview-handoff",
-      "pullRequest": null,
+      "pullRequest": "https://github.com/DigitalHerencia/LoadedVibes/pull/110",
       "evidence": {
         "executed": [
           "corepack pnpm exec vitest run tests/unit/web-configurator.test.ts (5 tests passed)",

--- a/.agents/execution/progress.json
+++ b/.agents/execution/progress.json
@@ -2,9 +2,9 @@
   "schemaVersion": 2,
   "roadmap": "generator-product-roadmap",
   "status": "in_progress",
-  "activeIssue": 99,
-  "activeBranch": "feature/99-web-configurator",
-  "completed": [92, 93, 94, 95, 96, 97, 98],
+  "activeIssue": 100,
+  "activeBranch": "feature/100-live-preview-handoff",
+  "completed": [92, 93, 94, 95, 96, 97, 98, 99],
   "workItems": [
     {
       "id": "LV-101",
@@ -133,7 +133,7 @@
     {
       "id": "LV-108",
       "issue": 99,
-      "status": "implemented",
+      "status": "verified",
       "branch": "feature/99-web-configurator",
       "pullRequest": "https://github.com/DigitalHerencia/LoadedVibes/pull/109",
       "evidence": {
@@ -143,6 +143,22 @@
           "corepack pnpm lint",
           "corepack pnpm web:build (static route generated)",
           "corepack pnpm validate (34 unit/integration tests and 7 generated CLI tests passed)"
+        ],
+        "blocked": []
+      }
+    },
+    {
+      "id": "LV-109",
+      "issue": 100,
+      "status": "implemented",
+      "branch": "feature/100-live-preview-handoff",
+      "pullRequest": null,
+      "evidence": {
+        "executed": [
+          "corepack pnpm exec vitest run tests/unit/web-configurator.test.ts (5 tests passed)",
+          "corepack pnpm --dir apps/web typecheck",
+          "corepack pnpm lint",
+          "corepack pnpm web:build (static route generated)"
         ],
         "blocked": []
       }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -111,7 +111,7 @@ button {
 }
 .workspace {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 390px;
+  grid-template-columns: minmax(0, 1fr) minmax(460px, 590px);
   gap: 24px;
   align-items: start;
 }
@@ -393,6 +393,455 @@ fieldset {
   font-size: 12px;
   line-height: 1.4;
 }
+.live-preview {
+  padding: 18px 0 6px;
+  border-bottom: 1px solid #ffffff24;
+}
+.preview-tabs {
+  display: flex;
+  gap: 5px;
+  overflow-x: auto;
+  padding-bottom: 10px;
+  scrollbar-width: thin;
+}
+.preview-tabs button {
+  flex: 0 0 auto;
+  border: 1px solid #ffffff31;
+  background: transparent;
+  color: #aaa;
+  padding: 7px 9px;
+  font-size: 10px;
+  cursor: pointer;
+}
+.preview-tabs button[data-active='true'] {
+  color: #171915;
+  background: var(--acid);
+  border-color: var(--acid);
+  font-weight: 800;
+}
+.preview-tabs button[data-unavailable='true']:after {
+  content: ' ·';
+  color: var(--orange);
+}
+.app-frame {
+  position: relative;
+  display: grid;
+  grid-template-columns: 92px minmax(0, 1fr);
+  grid-template-rows: 42px minmax(300px, auto);
+  min-height: 342px;
+  overflow: hidden;
+  background: #f7f5ef;
+  color: #1b1d18;
+  border: 1px solid #ffffff35;
+  font-size: 9px;
+}
+.app-frame[data-navigation='topbar'] {
+  grid-template-columns: 1fr;
+  grid-template-rows: 42px 31px minmax(269px, auto);
+}
+.app-bar {
+  grid-column: 1/-1;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 11px;
+  border-bottom: 1px solid #d8d7d0;
+  background: #fff;
+}
+.app-logo {
+  display: grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  background: #171915;
+  color: var(--acid);
+  font:
+    800 7px/1 ui-monospace,
+    monospace;
+}
+.app-bar strong {
+  flex: 1;
+}
+.avatar {
+  display: grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: #e2e5d7;
+  font-size: 7px;
+  font-weight: 800;
+}
+.avatar.large {
+  width: 38px;
+  height: 38px;
+  font-size: 10px;
+}
+.app-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  padding: 13px 9px;
+  background: #eeece5;
+  border-right: 1px solid #d8d7d0;
+  color: #666;
+}
+.app-nav span,
+.app-nav b {
+  padding: 6px 7px;
+}
+.app-nav b {
+  background: #dfe5cb;
+  color: #1b1d18;
+}
+.app-nav .nav-label {
+  padding-top: 0;
+  color: #96998f;
+  font:
+    700 6px/1 ui-monospace,
+    monospace;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.app-frame[data-navigation='topbar'] .app-nav {
+  flex-direction: row;
+  align-items: center;
+  padding: 4px 10px;
+  border-right: 0;
+  border-bottom: 1px solid #d8d7d0;
+}
+.app-frame[data-navigation='topbar'] .nav-label {
+  display: none;
+}
+.app-frame[data-navigation='topbar'] .app-canvas {
+  grid-column: 1;
+}
+.app-canvas {
+  min-width: 0;
+  background: #f7f5ef;
+}
+.surface-content {
+  padding: 18px;
+}
+.surface-heading > span,
+.surface-empty > span {
+  color: #657817;
+  font:
+    800 6px/1 ui-monospace,
+    monospace;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+.surface-heading h3,
+.surface-empty h3 {
+  margin: 6px 0 4px;
+  font:
+    600 20px/1 Georgia,
+    serif;
+}
+.surface-heading p,
+.surface-empty p {
+  max-width: 340px;
+  color: #74776d;
+  font-size: 8px;
+  line-height: 1.45;
+}
+.stat-row {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 7px;
+  margin: 15px 0 10px;
+}
+.stat-row div {
+  padding: 10px;
+  background: white;
+  border: 1px solid #deddd6;
+}
+.stat-row small,
+.plan-card small,
+.settings-grid small {
+  display: block;
+  color: #81847b;
+  font-size: 7px;
+}
+.stat-row b {
+  display: block;
+  margin-top: 4px;
+  font:
+    600 17px/1 Georgia,
+    serif;
+}
+.activity-card,
+.wizard-card,
+.settings-grid > div,
+.plan-card,
+.detail-form,
+.member-list {
+  background: white;
+  border: 1px solid #deddd6;
+  padding: 11px;
+}
+.activity-card > div {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+.app-canvas button {
+  border: 0;
+  background: #1b1d18;
+  color: #fff;
+  padding: 6px 8px;
+  font-size: 7px;
+  font-weight: 700;
+}
+.activity-card > span {
+  display: grid;
+  grid-template-columns: 8px 1fr auto;
+  gap: 5px;
+  align-items: center;
+  padding: 7px 0;
+  border-top: 1px solid #ecebe5;
+}
+.activity-card > span i {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--acid);
+}
+.activity-card > span small {
+  color: #8a8d84;
+}
+.progress-meta {
+  display: flex;
+  justify-content: space-between;
+}
+.progress-track {
+  height: 5px;
+  background: #deddd6;
+  margin: 9px 0 18px;
+}
+.progress-track i {
+  display: block;
+  width: 66%;
+  height: 100%;
+  background: #657817;
+}
+.wizard-card {
+  max-width: 250px;
+  margin: auto;
+  text-align: center;
+  padding: 20px;
+}
+.surface-icon {
+  display: grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  margin: 0 auto 9px;
+  background: var(--acid);
+  color: #171915;
+  font-weight: 900;
+}
+.wizard-card h3 {
+  margin: 0 0 5px;
+  font:
+    600 16px/1 Georgia,
+    serif;
+}
+.wizard-card p {
+  color: #777;
+  font-size: 8px;
+}
+.fake-input {
+  margin: 13px 0 8px;
+  padding: 8px;
+  text-align: left;
+  border: 1px solid #d3d2cb;
+  color: #979990;
+}
+.settings-grid,
+.detail-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+  margin-top: 15px;
+}
+.settings-grid > div {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 5px;
+}
+.settings-grid button {
+  margin-top: auto;
+}
+.plan-card {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 15px;
+}
+.plan-card > div {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.plan-card > b {
+  font:
+    600 22px/1 Georgia,
+    serif;
+}
+.plan-card > b small {
+  display: inline;
+  font:
+    400 7px/1 ui-sans-serif,
+    sans-serif;
+}
+.usage {
+  margin: 9px 0;
+  padding: 10px;
+  background: #ecebe5;
+}
+.usage i {
+  display: block;
+  height: 4px;
+  margin-top: 7px;
+  background: #d5d4cc;
+}
+.usage em {
+  display: block;
+  width: 66%;
+  height: 100%;
+  background: #657817;
+}
+.connect-note {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px;
+  border: 1px solid #9184ff;
+  background: #e9e7ff;
+}
+.detail-form,
+.member-list {
+  display: grid;
+  gap: 6px;
+}
+.detail-form label {
+  color: #777;
+  font-size: 7px;
+}
+.detail-form > div {
+  padding: 7px;
+  border: 1px solid #ddd;
+  color: #666;
+}
+.member-list > span {
+  display: grid;
+  grid-template-columns: 22px 1fr auto;
+  align-items: center;
+  gap: 5px;
+  padding-top: 7px;
+  border-top: 1px solid #eee;
+}
+.member-list i {
+  display: grid;
+  place-items: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #e2e5d7;
+  font-style: normal;
+  font-size: 6px;
+}
+.member-list b {
+  font-size: 6px;
+  color: #657817;
+  text-transform: uppercase;
+}
+.marketing-surface {
+  display: flex;
+  min-height: 299px;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  background: linear-gradient(135deg, #eef3df, #f7f5ef 58%, #ffe7dc);
+}
+.marketing-pill {
+  padding: 5px 7px;
+  background: #dfe8bf;
+  color: #526312;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.marketing-surface h3 {
+  max-width: 350px;
+  margin: 12px 0 7px;
+  font:
+    600 25px/0.98 Georgia,
+    serif;
+  letter-spacing: -0.03em;
+}
+.marketing-surface > p {
+  max-width: 300px;
+  color: #6d7067;
+  line-height: 1.5;
+}
+.marketing-surface .secondary {
+  margin-left: 5px;
+  background: transparent;
+  color: #1b1d18;
+  border: 1px solid #aaa;
+}
+.trust-row {
+  display: flex;
+  gap: 12px;
+  margin-top: 20px;
+  color: #777;
+  font-size: 7px;
+}
+.surface-empty {
+  display: grid;
+  min-height: 300px;
+  place-content: center;
+  padding: 35px;
+  text-align: center;
+}
+.representative-note {
+  margin: 7px 0 0;
+  color: #888;
+  font-size: 8px;
+  text-align: center;
+}
+.review[data-theme='paper'] .live-preview {
+  border-bottom-color: #dedbd0;
+}
+.review[data-theme='electric'] .app-logo {
+  background: #231ae8;
+}
+.review[data-theme='electric'] .app-nav b,
+.review[data-theme='electric'] .progress-track i,
+.review[data-theme='electric'] .usage em {
+  background: #ffdf38;
+}
+.review[data-radius='rounded'] .app-frame,
+.review[data-radius='rounded'] .app-canvas button,
+.review[data-radius='rounded'] .activity-card,
+.review[data-radius='rounded'] .wizard-card,
+.review[data-radius='rounded'] .settings-grid > div,
+.review[data-radius='rounded'] .plan-card,
+.review[data-radius='rounded'] .detail-form,
+.review[data-radius='rounded'] .member-list {
+  border-radius: 9px;
+}
+.review[data-density='compact'] .app-frame {
+  grid-template-rows: 38px minmax(270px, auto);
+  min-height: 310px;
+}
+.review[data-density='compact'] .surface-content {
+  padding: 12px;
+}
 .review[data-theme='paper'] .product-preview p,
 .review[data-theme='paper'] .review-top,
 .review[data-theme='paper'] .privacy {
@@ -505,6 +954,21 @@ details p {
   }
   .preset-grid {
     grid-template-columns: 1fr 1fr;
+  }
+}
+@media (max-width: 560px) {
+  .app-frame {
+    grid-template-columns: 72px minmax(0, 1fr);
+  }
+  .surface-content {
+    padding: 12px;
+  }
+  .settings-grid,
+  .detail-grid {
+    grid-template-columns: 1fr;
+  }
+  .marketing-surface h3 {
+    font-size: 20px;
   }
 }
 @media (max-width: 560px) {

--- a/apps/web/components/configurator.tsx
+++ b/apps/web/components/configurator.tsx
@@ -8,6 +8,7 @@ import {
   type ProductPresetId,
 } from '@loaded-vibes/core/browser';
 import { useEffect, useMemo, useState } from 'react';
+import { LivePreview } from '@/components/live-preview';
 import {
   configurableCapabilities,
   createCliCommand,
@@ -294,7 +295,7 @@ export function Configurator() {
           data-density={draft.design.density}
         >
           <div className="review-top">
-            <span>Recipe preview</span>
+            <span>Live product preview</span>
             <span className="schema">schema v1</span>
           </div>
           <div className="product-preview">
@@ -309,6 +310,7 @@ export function Configurator() {
               </p>
             </div>
           </div>
+          <LivePreview recipe={resolved.recipe} />
           <div className="summary-block">
             <small>Starting point</small>
             <strong>{resolved.summary.preset.label}</strong>

--- a/apps/web/components/live-preview.tsx
+++ b/apps/web/components/live-preview.tsx
@@ -1,0 +1,313 @@
+'use client';
+
+import type { NormalizedRecipe } from '@loaded-vibes/core/browser';
+import { useState } from 'react';
+import { getPreviewSurfaces, type PreviewSurfaceId } from '@/lib/preview';
+
+function productLanguage(recipe: NormalizedRecipe) {
+  if (recipe.product === 'client-portal') {
+    return {
+      singular: 'workspace',
+      plural: 'workspaces',
+      action: 'Open client workspace',
+    };
+  }
+  if (recipe.product === 'platform-marketplace') {
+    return {
+      singular: 'listing',
+      plural: 'listings',
+      action: 'Review new listing',
+    };
+  }
+  return { singular: 'project', plural: 'projects', action: 'Create project' };
+}
+
+export function LivePreview({ recipe }: { recipe: NormalizedRecipe }) {
+  const [active, setActive] = useState<PreviewSurfaceId>('dashboard');
+  const surfaces = getPreviewSurfaces(recipe);
+  const selected =
+    surfaces.find((surface) => surface.id === active) ?? surfaces[0]!;
+  const language = productLanguage(recipe);
+
+  return (
+    <div className="live-preview">
+      <div
+        className="preview-tabs"
+        role="tablist"
+        aria-label="Representative application surfaces"
+      >
+        {surfaces.map((surface) => (
+          <button
+            key={surface.id}
+            type="button"
+            role="tab"
+            aria-selected={active === surface.id}
+            data-active={active === surface.id}
+            data-unavailable={!surface.available}
+            onClick={() => setActive(surface.id)}
+          >
+            {surface.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="app-frame" data-navigation={recipe.design.navigation}>
+        <header className="app-bar">
+          <span className="app-logo">
+            {recipe.identity.displayName.slice(0, 2).toUpperCase()}
+          </span>
+          <strong>{recipe.identity.displayName}</strong>
+          <span className="avatar">JD</span>
+        </header>
+        <nav className="app-nav" aria-label="Preview navigation">
+          <span className="nav-label">Workspace</span>
+          <b>Overview</b>
+          <span>{language.plural}</span>
+          {recipe.modules.billing && <span>Billing</span>}
+          <span>Settings</span>
+        </nav>
+        <section className="app-canvas" role="tabpanel">
+          {!selected.available ? (
+            <UnavailableSurface
+              label={selected.label}
+              requirement={selected.requirement!}
+            />
+          ) : (
+            <PreviewSurface
+              surface={active}
+              recipe={recipe}
+              language={language}
+            />
+          )}
+        </section>
+      </div>
+      <p className="representative-note">
+        Representative preview · content illustrates generated surfaces, not
+        live product data.
+      </p>
+    </div>
+  );
+}
+
+function UnavailableSurface({
+  label,
+  requirement,
+}: {
+  label: string;
+  requirement: string;
+}) {
+  return (
+    <div className="surface-empty">
+      <span>Not in this recipe</span>
+      <h3>{label} stays out.</h3>
+      <p>
+        Enable {requirement.toLowerCase()} to include and preview this generated
+        surface.
+      </p>
+    </div>
+  );
+}
+
+function SurfaceHeading({
+  eyebrow,
+  title,
+  description,
+}: {
+  eyebrow: string;
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="surface-heading">
+      <span>{eyebrow}</span>
+      <h3>{title}</h3>
+      <p>{description}</p>
+    </div>
+  );
+}
+
+function PreviewSurface({
+  surface,
+  recipe,
+  language,
+}: {
+  surface: PreviewSurfaceId;
+  recipe: NormalizedRecipe;
+  language: ReturnType<typeof productLanguage>;
+}) {
+  if (surface === 'onboarding') {
+    return (
+      <div className="surface-content onboarding-surface">
+        <div className="progress-meta">
+          <strong>Set up your workspace</strong>
+          <span>2 of 3</span>
+        </div>
+        <div className="progress-track">
+          <i />
+        </div>
+        <div className="wizard-card">
+          <span className="surface-icon">02</span>
+          <h3>Invite your team</h3>
+          <p>
+            Bring the people who will help run {recipe.identity.displayName}.
+          </p>
+          <div className="fake-input">teammate@company.com</div>
+          <button>Continue</button>
+        </div>
+      </div>
+    );
+  }
+
+  if (surface === 'settings') {
+    return (
+      <div className="surface-content">
+        <SurfaceHeading
+          eyebrow="Settings"
+          title="Account and workspace"
+          description="Identity stays provider-owned. Product authorization remains local."
+        />
+        <div className="settings-grid">
+          <div>
+            <span className="avatar large">JD</span>
+            <strong>Jordan Diaz</strong>
+            <small>jordan@example.com</small>
+          </div>
+          <div>
+            <small>Workspace</small>
+            <strong>{recipe.identity.displayName}</strong>
+            <button>Manage members</button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (surface === 'billing') {
+    return (
+      <div className="surface-content">
+        <SurfaceHeading
+          eyebrow="Billing"
+          title="Plan and usage"
+          description="Hosted checkout and verified webhooks keep subscription truth reliable."
+        />
+        <div className="plan-card">
+          <div>
+            <small>Current plan</small>
+            <strong>Growth</strong>
+            <span>Active · renews Sep 9</span>
+          </div>
+          <b>
+            $49<small>/mo</small>
+          </b>
+        </div>
+        <div className="usage">
+          <span>
+            <b>8</b> of 12 seats
+          </span>
+          <i>
+            <em />
+          </i>
+        </div>
+        {recipe.modules.stripeConnect && (
+          <div className="connect-note">
+            <b>Connect enabled</b>
+            <span>Platform payments are included in this recipe.</span>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  if (surface === 'workflow') {
+    return (
+      <div className="surface-content">
+        <SurfaceHeading
+          eyebrow="Owner"
+          title="Launch plan"
+          description={`A representative ${language.singular} detail backed by authorized server workflows.`}
+        />
+        <div className="detail-grid">
+          <div className="detail-form">
+            <label>Name</label>
+            <div>Launch plan</div>
+            <label>Description</label>
+            <div>Coordinate the product rollout.</div>
+            <button>Save {language.singular}</button>
+          </div>
+          <div className="member-list">
+            <strong>Members</strong>
+            <span>
+              <i>JD</i> Jordan Diaz <b>Owner</b>
+            </span>
+            <span>
+              <i>AK</i> Avery Kim <b>Member</b>
+            </span>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (surface === 'marketing') {
+    return (
+      <div className="surface-content marketing-surface">
+        <span className="marketing-pill">Built for focused teams</span>
+        <h3>
+          {recipe.identity.description ||
+            `Move your work forward with ${recipe.identity.displayName}.`}
+        </h3>
+        <p>
+          A clear public starting point that hands qualified users into the
+          product.
+        </p>
+        <div>
+          <button>Start free</button>
+          <button className="secondary">See how it works</button>
+        </div>
+        <div className="trust-row">
+          <span>Fast onboarding</span>
+          <span>Team ready</span>
+          <span>Secure by default</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="surface-content">
+      <SurfaceHeading
+        eyebrow="Workspace dashboard"
+        title="Operational center"
+        description={`See what is moving across your ${language.plural}.`}
+      />
+      <div className="stat-row">
+        <div>
+          <small>Active {language.plural}</small>
+          <b>{recipe.modules.sampleDomain ? '12' : '—'}</b>
+        </div>
+        <div>
+          <small>Team members</small>
+          <b>{recipe.modules.invitations ? '8' : '1'}</b>
+        </div>
+        <div>
+          <small>Plan</small>
+          <b>{recipe.modules.billing ? 'Growth' : 'Free'}</b>
+        </div>
+      </div>
+      <div className="activity-card">
+        <div>
+          <strong>Recent activity</strong>
+          <button>{language.action}</button>
+        </div>
+        <span>
+          <i />
+          Launch plan <small>Updated 12m ago</small>
+        </span>
+        <span>
+          <i />
+          Customer research <small>Updated yesterday</small>
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/lib/preview.ts
+++ b/apps/web/lib/preview.ts
@@ -1,0 +1,50 @@
+import type { NormalizedRecipe } from '@loaded-vibes/core/browser';
+
+export const previewSurfaceIds = [
+  'dashboard',
+  'onboarding',
+  'settings',
+  'billing',
+  'workflow',
+  'marketing',
+] as const;
+
+export type PreviewSurfaceId = (typeof previewSurfaceIds)[number];
+
+export interface PreviewSurface {
+  id: PreviewSurfaceId;
+  label: string;
+  available: boolean;
+  requirement?: string;
+}
+
+export function getPreviewSurfaces(recipe: NormalizedRecipe): PreviewSurface[] {
+  return [
+    { id: 'dashboard', label: 'Dashboard', available: true },
+    {
+      id: 'onboarding',
+      label: 'Onboarding',
+      available: recipe.modules.onboarding,
+      requirement: 'Product onboarding',
+    },
+    { id: 'settings', label: 'Settings', available: true },
+    {
+      id: 'billing',
+      label: 'Billing',
+      available: recipe.modules.billing,
+      requirement: 'Subscription billing',
+    },
+    {
+      id: 'workflow',
+      label: 'Detail',
+      available: recipe.modules.sampleDomain !== false,
+      requirement: 'Sample projects domain',
+    },
+    {
+      id: 'marketing',
+      label: 'Marketing',
+      available: recipe.modules.marketing,
+      requirement: 'Marketing site',
+    },
+  ];
+}

--- a/tests/unit/web-configurator.test.ts
+++ b/tests/unit/web-configurator.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { normalizeConfig, type ConfigInput } from '@loaded-vibes/core';
 import {
   createCliCommand,
   defaultConfiguratorRecipe,
@@ -8,6 +9,7 @@ import {
   serializeRecipe,
   setCapability,
 } from '../../apps/web/lib/configurator.js';
+import { getPreviewSurfaces } from '../../apps/web/lib/preview.js';
 
 describe('web configurator recipe', () => {
   it('uses the same preset resolver as the CLI', () => {
@@ -35,11 +37,31 @@ describe('web configurator recipe', () => {
   it('round trips a normalized reproducible recipe', () => {
     const serialized = serializeRecipe(defaultConfiguratorRecipe);
     expect(serializeRecipe(deserializeRecipe(serialized))).toBe(serialized);
+    expect(
+      normalizeConfig(JSON.parse(serialized) as ConfigInput, 'D:/recipes')
+        .recipe.name,
+    ).toBe('my-saas');
   });
 
   it('provides a self-contained package command', () => {
     expect(createCliCommand(defaultConfiguratorRecipe)).toBe(
       'pnpm dlx create-loaded-vibes@latest my-saas --config loadedvibes.json --yes',
     );
+  });
+
+  it('exposes only preview surfaces supported by the resolved recipe', () => {
+    const bare = resolveConfiguratorRecipe(
+      selectProductPreset(defaultConfiguratorRecipe, 'bare-golden-app'),
+    ).recipe;
+    const surfaces = getPreviewSurfaces(bare);
+    expect(
+      surfaces.find((surface) => surface.id === 'dashboard')?.available,
+    ).toBe(true);
+    expect(
+      surfaces.find((surface) => surface.id === 'billing')?.available,
+    ).toBe(false);
+    expect(
+      surfaces.find((surface) => surface.id === 'workflow')?.available,
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- add six representative Vibes-aligned application preview surfaces
- bind preview identity, product language, theme, navigation, density, and capability availability to the resolved recipe
- clearly label excluded surfaces instead of simulating unsupported behavior
- verify exported JSON against the same config normalization consumed by the CLI

## QA
- corepack pnpm exec vitest run tests/unit/web-configurator.test.ts (5 passed)
- corepack pnpm --dir apps/web typecheck`n- corepack pnpm lint`n- corepack pnpm web:build (static route generated)

Closes #100