### PR TITLE
docs(web): add canonical user guide

### DIFF
--- a/.agents/execution/handoff.json
+++ b/.agents/execution/handoff.json
@@ -2,28 +2,27 @@
   "schemaVersion": 3,
   "handoff": {
     "repository": "DigitalHerencia/LoadedVibes",
-    "branch": "feat/115-web-landing-configurator",
-    "observedRevision": "99df947",
-    "activeIssue": 115,
-    "activeSpec": "context/specs/LV-204-web-landing-configurator.md",
-    "objective": "Separate the concise Loaded Vibes landing page from the stateless visual configuration workbench and expose only generator-backed choices.",
+    "branch": "docs/116-end-user-docs",
+    "observedRevision": "5f9d6a0",
+    "activeIssue": 116,
+    "activeSpec": "context/specs/LV-205-end-user-docs.md",
+    "objective": "Create one canonical docs/ source for current Loaded Vibes behavior and render it under /docs without duplicating maintainer context.",
     "readFirst": [
       "AGENTS.md",
       "context/README.md",
-      "context/specs/LV-204-web-landing-configurator.md",
-      "context/docs/web.md",
+      "context/specs/LV-205-end-user-docs.md",
+      "context/docs/documentation.md",
       "context/docs/product.md",
-      "context/docs/configuration.md",
-      ".agents/contracts/product.yaml",
-      "apps/web/app/page.tsx",
-      "apps/web/app/configure/page.tsx",
-      "apps/web/components/configurator.tsx"
+      "context/docs/generator-cli.md",
+      "docs/index.md",
+      "apps/web/app/docs/[[...slug]]/page.tsx",
+      "apps/web/lib/docs.tsx"
     ],
     "doNot": [
       "reintroduce DigitalHerencia/Vibes",
-      "add accounts or server state",
-      "add hosted generation",
-      "show choices the generator cannot honor",
+      "duplicate maintainer context",
+      "document unsupported providers or commands",
+      "add a documentation CMS",
       "add new tests or validation systems",
       "claim checks that were not run"
     ]

--- a/.agents/execution/progress.json
+++ b/.agents/execution/progress.json
@@ -1,12 +1,12 @@
 {
   "schemaVersion": 3,
   "status": "in-progress",
-  "observedRevision": "99df947",
+  "observedRevision": "5f9d6a0",
   "observedDate": "2026-08-09",
-  "currentOutcome": "LV-204 separates the developer landing page from the stateless configuration workbench and presents only generator-backed options.",
-  "activeIssue": 115,
-  "activeSpec": "context/specs/LV-204-web-landing-configurator.md",
-  "openIssuesObserved": 4,
+  "currentOutcome": "LV-205 establishes docs/ as the canonical end-user source and renders it under /docs from the same Markdown files.",
+  "activeIssue": 116,
+  "activeSpec": "context/specs/LV-205-end-user-docs.md",
+  "openIssuesObserved": 3,
   "openPullRequestsObserved": 0,
   "completedPriorRoadmap": "LV-101 through LV-110",
   "nextRoadmap": [
@@ -25,6 +25,7 @@
     "package.json publishes the sole template source",
     "package.json name is create-loaded-vibes and exposes both create-loaded-vibes and loaded-vibes bins",
     "the web root is the concise developer landing page and /configure owns the workbench",
+    "docs/ is the canonical end-user source rendered by /docs",
     "root and context governance already prohibit using DigitalHerencia/Vibes as template authority"
   ],
   "evidenceThisArtifactDidNotExecute": [
@@ -35,5 +36,5 @@
     "package smoke checks",
     "deployments"
   ],
-  "nextAction": "Finish LV-204 web verification, open its focused pull request, and merge before starting LV-205."
+  "nextAction": "Finish LV-205 web verification, open its focused pull request, and merge before starting LV-206."
 }

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Loaded Vibes turns a few product choices into a recognizable SaaS starting point. It combines an enjoyable CLI, a stateless visual configurator, reproducible `loadedvibes.json` recipes, and one packaged maximal white-label application template—without asking you to redesign the stack.
 
+The canonical end-user guide lives in [`docs/`](docs/index.md) and is rendered by the website under `/docs/*`. Start with [Getting started](docs/getting-started.md), then use the [configuration](docs/concepts/configuration.md) and [CLI](docs/cli/index.md) references as needed.
+
 ## Create a project
 
 Node.js 24 is required. Run the package without installing it globally:

--- a/apps/web/app/docs/[[...slug]]/page.tsx
+++ b/apps/web/app/docs/[[...slug]]/page.tsx
@@ -1,0 +1,42 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import {
+  documentation,
+  readDocumentation,
+  renderDocumentation,
+} from '@/lib/docs';
+
+export function generateStaticParams() {
+  return documentation.map((entry) => ({ slug: [...entry.slug] }));
+}
+
+export default async function DocumentationPage({
+  params,
+}: {
+  params: Promise<{ slug?: string[] }>;
+}) {
+  const { slug = [] } = await params;
+  const source = readDocumentation(slug);
+  if (!source) notFound();
+
+  return (
+    <main className="shell docs-shell">
+      <aside className="docs-navigation">
+        <span>Documentation</span>
+        {documentation.map((entry) => {
+          const href = `/docs${entry.slug.length ? `/${entry.slug.join('/')}` : ''}`;
+          return (
+            <Link
+              data-active={entry.slug.join('/') === slug.join('/')}
+              href={href}
+              key={href}
+            >
+              {entry.title}
+            </Link>
+          );
+        })}
+      </aside>
+      <article className="docs-content">{renderDocumentation(source)}</article>
+    </main>
+  );
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -177,6 +177,84 @@ button {
   font-size: 23px;
   line-height: 1.15;
 }
+.docs-shell {
+  display: grid;
+  grid-template-columns: 220px minmax(0, 760px);
+  gap: 70px;
+  align-items: start;
+  padding-top: 58px;
+}
+.docs-navigation {
+  position: sticky;
+  top: 28px;
+  display: grid;
+  gap: 4px;
+  padding: 18px;
+  border: 1px solid var(--line);
+  background: #0b0b12cc;
+}
+.docs-navigation > span {
+  margin: 2px 8px 12px;
+  color: var(--acid);
+  font:
+    700 10px/1 ui-monospace,
+    monospace;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.docs-navigation a {
+  padding: 8px;
+  color: var(--muted);
+  font-size: 13px;
+  text-decoration: none;
+}
+.docs-navigation a:hover,
+.docs-navigation a[data-active='true'] {
+  color: var(--ink);
+  background: #8b5cf619;
+}
+.docs-content {
+  min-width: 0;
+  padding-bottom: 90px;
+}
+.docs-content h1 {
+  margin: 0 0 28px;
+  font-size: clamp(42px, 6vw, 70px);
+  line-height: 0.98;
+  letter-spacing: -0.05em;
+}
+.docs-content h2 {
+  margin: 48px 0 16px;
+  font-size: 26px;
+}
+.docs-content h3 {
+  margin: 32px 0 12px;
+}
+.docs-content p,
+.docs-content li {
+  color: #b3b0c1;
+  line-height: 1.75;
+}
+.docs-content a {
+  color: var(--acid);
+}
+.docs-content code {
+  color: #d8caff;
+  font-family: ui-monospace, monospace;
+}
+.docs-content p code,
+.docs-content li code {
+  padding: 2px 5px;
+  border: 1px solid var(--line);
+  background: #11111a;
+}
+.docs-content pre {
+  overflow-x: auto;
+  padding: 18px;
+  border: 1px solid var(--line);
+  background: #09090f;
+  line-height: 1.6;
+}
 .factory-flow p,
 .foundation-callout > p {
   color: var(--muted);
@@ -1012,8 +1090,19 @@ details p {
     padding: 52px 0 40px;
   }
   .factory-flow,
-  .foundation-callout {
+  .foundation-callout,
+  .docs-shell {
     grid-template-columns: 1fr;
+  }
+  .docs-shell {
+    gap: 34px;
+  }
+  .docs-navigation {
+    position: static;
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .docs-navigation > span {
+    grid-column: 1 / -1;
   }
   .factory-flow article {
     border-right: 0;

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -19,6 +19,9 @@ export default function Home() {
             Configure a project
           </Link>
           <code>pnpm dlx create-loaded-vibes@latest</code>
+          <Link className="button" href="/docs/getting-started">
+            Read the docs
+          </Link>
         </div>
       </section>
 

--- a/apps/web/components/site-header.tsx
+++ b/apps/web/components/site-header.tsx
@@ -9,6 +9,7 @@ export function SiteHeader() {
       </Link>
       <nav aria-label="Primary navigation">
         <Link href="/">Overview</Link>
+        <Link href="/docs">Docs</Link>
         <Link className="nav-cta" href="/configure">
           Open configurator
         </Link>

--- a/apps/web/lib/docs.tsx
+++ b/apps/web/lib/docs.tsx
@@ -1,0 +1,123 @@
+import 'server-only';
+import fs from 'node:fs';
+import path from 'node:path';
+import type { ReactNode } from 'react';
+
+export const documentation = [
+  { slug: [], title: 'Overview' },
+  { slug: ['getting-started'], title: 'Getting started' },
+  { slug: ['concepts', 'one-template'], title: 'One template' },
+  { slug: ['concepts', 'configuration'], title: 'Configuration contract' },
+  { slug: ['concepts', 'generated-project'], title: 'Generated project' },
+  { slug: ['configuration', 'project'], title: 'Project' },
+  { slug: ['configuration', 'optional-surfaces'], title: 'Optional surfaces' },
+  { slug: ['configuration', 'integrations'], title: 'Integrations' },
+  { slug: ['configuration', 'identity'], title: 'Identity' },
+  { slug: ['configuration', 'design'], title: 'Design' },
+  { slug: ['cli'], title: 'CLI reference' },
+  { slug: ['cli', 'create'], title: 'Create' },
+  { slug: ['cli', 'add'], title: 'Add' },
+  { slug: ['cli', 'explain'], title: 'Explain' },
+  { slug: ['cli', 'doctor'], title: 'Doctor' },
+  { slug: ['troubleshooting'], title: 'Troubleshooting' },
+] as const;
+
+const docsRoot = path.resolve(process.cwd(), '../../docs');
+
+export function readDocumentation(slug: readonly string[]): string | null {
+  const entry = documentation.find(
+    (candidate) => candidate.slug.join('/') === slug.join('/'),
+  );
+  if (!entry) return null;
+  if (!entry.slug.length)
+    return fs.readFileSync(path.join(docsRoot, 'index.md'), 'utf8');
+  const stem = path.join(docsRoot, ...entry.slug);
+  const file = fs.existsSync(stem) ? path.join(stem, 'index.md') : `${stem}.md`;
+  return fs.readFileSync(file, 'utf8');
+}
+
+function inline(value: string): ReactNode[] {
+  const parts = value.split(/(`[^`]+`|\[[^\]]+\]\([^)]+\))/g);
+  return parts.map((part, index) => {
+    const link = part.match(/^\[([^\]]+)\]\(([^)]+)\)$/);
+    if (link)
+      return (
+        <a key={index} href={link[2]}>
+          {link[1]}
+        </a>
+      );
+    if (part.startsWith('`') && part.endsWith('`')) {
+      return <code key={index}>{part.slice(1, -1)}</code>;
+    }
+    return part;
+  });
+}
+
+export function renderDocumentation(source: string): ReactNode[] {
+  const lines = source.replace(/\r\n/g, '\n').split('\n');
+  const output: ReactNode[] = [];
+  let index = 0;
+
+  while (index < lines.length) {
+    const line = lines[index]!;
+    if (!line.trim()) {
+      index += 1;
+      continue;
+    }
+    if (line.startsWith('```')) {
+      const language = line.slice(3);
+      const code: string[] = [];
+      index += 1;
+      while (index < lines.length && !lines[index]!.startsWith('```')) {
+        code.push(lines[index]!);
+        index += 1;
+      }
+      output.push(
+        <pre key={output.length} data-language={language}>
+          <code>{code.join('\n')}</code>
+        </pre>,
+      );
+      index += 1;
+      continue;
+    }
+    const heading = line.match(/^(#{1,3})\s+(.+)$/);
+    if (heading) {
+      const content = inline(heading[2]!);
+      const key = output.length;
+      output.push(
+        heading[1]!.length === 1 ? (
+          <h1 key={key}>{content}</h1>
+        ) : heading[1]!.length === 2 ? (
+          <h2 key={key}>{content}</h2>
+        ) : (
+          <h3 key={key}>{content}</h3>
+        ),
+      );
+      index += 1;
+      continue;
+    }
+    if (line.startsWith('- ')) {
+      const items: ReactNode[] = [];
+      while (index < lines.length && lines[index]!.startsWith('- ')) {
+        items.push(
+          <li key={items.length}>{inline(lines[index]!.slice(2))}</li>,
+        );
+        index += 1;
+      }
+      output.push(<ul key={output.length}>{items}</ul>);
+      continue;
+    }
+    const paragraph = [line];
+    index += 1;
+    while (
+      index < lines.length &&
+      lines[index]!.trim() &&
+      !/^(#{1,3})\s|^- |^```/.test(lines[index]!)
+    ) {
+      paragraph.push(lines[index]!);
+      index += 1;
+    }
+    output.push(<p key={output.length}>{inline(paragraph.join(' '))}</p>);
+  }
+  return output;
+}

--- a/docs/cli/add.md
+++ b/docs/cli/add.md
@@ -1,0 +1,9 @@
+# loaded-vibes add
+
+```powershell
+loaded-vibes add <marketing|sample-domain|stripe-connect> [--cwd <directory>]
+```
+
+Add applies a safe generator-owned compatibility projection to an existing generated project. It checks provenance and collisions before writing. Intentional replacement paths are declared by the ownership contract.
+
+This command is not a plugin installer, general source merger, or arbitrary template upgrade system.

--- a/docs/cli/create.md
+++ b/docs/cli/create.md
@@ -1,0 +1,9 @@
+# loaded-vibes create
+
+```powershell
+loaded-vibes create [directory] [options]
+```
+
+Create normalizes one recipe, resolves capability dependencies, reviews the plan, copies the master template, prunes excluded ownership, applies transforms, writes configuration and provenance, and optionally installs dependencies and initializes Git.
+
+Use `--config loadedvibes.json --yes` for reproducible non-interactive generation. See [project configuration](/docs/configuration/project) for supported flags.

--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -1,0 +1,9 @@
+# loaded-vibes doctor
+
+```powershell
+loaded-vibes doctor [--cwd <directory>]
+```
+
+Doctor checks generated-project metadata, local prerequisites, and actionable configuration readiness. A failed check includes the action to take before rerunning it.
+
+Doctor is not a full validation suite and does not prove provider-backed production journeys work.

--- a/docs/cli/explain.md
+++ b/docs/cli/explain.md
@@ -1,0 +1,7 @@
+# loaded-vibes explain
+
+```powershell
+loaded-vibes explain [--cwd <directory>]
+```
+
+Explain reads generated configuration and provenance, then reports product identity, preset, capabilities, packaged modules, design values, provider boundaries, inherited architecture, and remaining setup.

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -1,0 +1,9 @@
+# CLI reference
+
+The canonical executable is `loaded-vibes`. The package also exposes `create-loaded-vibes` for initializer compatibility.
+
+- [`create`](/docs/cli/create) generates a project.
+- [`add`](/docs/cli/add) adds one supported owned surface.
+- [`explain`](/docs/cli/explain) summarizes generated provenance.
+- [`doctor`](/docs/cli/doctor) diagnoses local readiness.
+- `loaded-vibes --version` prints the CLI version.

--- a/docs/concepts/configuration.md
+++ b/docs/concepts/configuration.md
@@ -1,0 +1,7 @@
+# Configuration contract
+
+The CLI, web configurator, and `loadedvibes.json` share one schema and normalization path.
+
+Configuration covers project lifecycle, a preset baseline, real optional surfaces, product identity, and bounded design values. Dependency resolution may enable prerequisites such as billing when Stripe Connect is selected. Organizations, local roles/authorization, and generated guidance are fixed.
+
+See [project settings](/docs/configuration/project), [optional surfaces](/docs/configuration/optional-surfaces), [integrations](/docs/configuration/integrations), [identity](/docs/configuration/identity), and [design](/docs/configuration/design).

--- a/docs/concepts/generated-project.md
+++ b/docs/concepts/generated-project.md
@@ -1,0 +1,7 @@
+# Generated project
+
+The generated repository is the product handoff. It contains application source, `loadedvibes.json`, `.loadedvibes/manifest.json`, a generated README, environment examples, migrations, and focused validation commands.
+
+The manifest records the recipe, template revision, retained and excluded ownership, applied transforms, and remaining setup. `loaded-vibes explain` reads this provenance; it does not contact a hosted control plane.
+
+After generation, the repository belongs to you. Loaded Vibes does not automatically merge arbitrary future template changes into user-modified source.

--- a/docs/concepts/one-template.md
+++ b/docs/concepts/one-template.md
@@ -1,0 +1,7 @@
+# One template
+
+Loaded Vibes owns one maximal Hipster Stack application template. Presets and configuration do not select alternate architectures.
+
+Generation copies that template once, removes excluded generator-owned paths, applies structured identity and design transforms, writes provenance, and optionally installs dependencies and initializes Git.
+
+The fixed foundation includes TypeScript, Next.js App Router, Prisma, Neon/PostgreSQL boundaries, Clerk identity, application-owned tenant authorization, server operations, and Vercel-oriented deployment. Optional surfaces change owned output without forking that architecture.

--- a/docs/configuration/design.md
+++ b/docs/configuration/design.md
@@ -1,0 +1,11 @@
+# Visual direction
+
+Design configuration is semantic and bounded:
+
+- theme: `obsidian`, `paper`, or `electric`;
+- appearance: `light`, `dark`, or `system`;
+- radius: `compact`, `medium`, or `rounded`;
+- density: `compact` or `comfortable`;
+- navigation: `sidebar` or `topbar`.
+
+These values personalize intentional template surfaces. They are not arbitrary component generation or a design-token editor.

--- a/docs/configuration/identity.md
+++ b/docs/configuration/identity.md
@@ -1,0 +1,9 @@
+# Product identity
+
+Supported identity fields are:
+
+- `name`: package-safe project name;
+- `identity.displayName`: visible product name;
+- `identity.description`: product promise, up to 160 characters.
+
+The generator applies these values through owned structured transforms. Product-specific domain language beyond the supported fields belongs in the generated repository.

--- a/docs/configuration/integrations.md
+++ b/docs/configuration/integrations.md
@@ -1,0 +1,7 @@
+# Integrations and provider ownership
+
+The template includes supported server-side boundaries for Clerk, Neon/PostgreSQL, Stripe, Cloudinary, Hugging Face, Mapbox, and Vercel-oriented deployment. Billing and Stripe Connect are optional generated surfaces; the other boundaries are part of the fixed template foundation.
+
+Loaded Vibes does not create provider accounts, collect secrets, provision infrastructure, run production migrations, register webhooks, choose commercial policy, or deploy for you.
+
+Start from the generated `.env.example`. Configure provider projects and credentials in your own environments, run `loaded-vibes doctor`, then verify every provider-backed journey before production promotion.

--- a/docs/configuration/optional-surfaces.md
+++ b/docs/configuration/optional-surfaces.md
@@ -1,0 +1,15 @@
+# Optional surfaces
+
+The generator can retain or remove these owned application surfaces:
+
+- membership invitations;
+- subscription billing;
+- Stripe Connect platform payments;
+- product onboarding;
+- administration;
+- public marketing/pricing;
+- the sample projects domain.
+
+Organizations, local roles and authorization, and generated project guidance are fixed. Stripe Connect requires billing and authorization; other prerequisites resolve automatically.
+
+Only `marketing`, `sample-domain`, and `stripe-connect` currently have safe post-generation `loaded-vibes add` contracts.

--- a/docs/configuration/project.md
+++ b/docs/configuration/project.md
@@ -1,0 +1,14 @@
+# Project configuration
+
+`loaded-vibes create [directory]` controls the destination. The recipe `name` controls package identity, while `identity.displayName` controls visible product naming.
+
+Lifecycle flags:
+
+- `--name <package-name>` overrides the recipe package name.
+- `--config <path>` loads the shared JSON contract.
+- `--yes` runs non-interactively.
+- `--no-git` skips Git initialization.
+- `--skip-install` skips dependency installation and generated acceptance validation.
+- `--dry-run` plans without writing files.
+
+Generation refuses an unsafe non-empty destination.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,28 @@
+# Getting started
+
+Loaded Vibes requires Node.js 24 and pnpm.
+
+## Generate a project
+
+```powershell
+pnpm dlx create-loaded-vibes@latest create my-product
+```
+
+The interactive flow asks about supported optional surfaces, identity, and visual direction. To generate reproducibly from an exported configuration:
+
+```powershell
+pnpm dlx create-loaded-vibes@latest create my-product --config loadedvibes.json --yes
+```
+
+Use `--dry-run` to review the plan without writing, `--skip-install` to leave dependencies uninstalled, or `--no-git` to skip repository initialization.
+
+## Continue locally
+
+Enter the generated directory, read its README and `.env.example`, configure the services you own, then run:
+
+```powershell
+loaded-vibes doctor
+loaded-vibes explain
+```
+
+Provider accounts, credentials, migrations, deployment, and production verification remain your responsibility.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,14 @@
+# Loaded Vibes documentation
+
+Loaded Vibes generates a complete white-label application from one repository-owned master template and a bounded configuration.
+
+## Start here
+
+- [Getting started](/docs/getting-started)
+- [The one-template model](/docs/concepts/one-template)
+- [Configuration](/docs/concepts/configuration)
+- [CLI reference](/docs/cli)
+- [Generated project handoff](/docs/concepts/generated-project)
+- [Troubleshooting](/docs/troubleshooting)
+
+The CLI runs generation locally. The visual configurator creates the same portable `loadedvibes.json` contract; it does not upload or build your project.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,21 @@
+# Troubleshooting
+
+## The destination is not empty
+
+Choose an empty directory. Loaded Vibes will not overwrite an existing project.
+
+## Installation was skipped or failed
+
+Run `corepack pnpm install` inside the generated project, then run its documented validation command.
+
+## Doctor reports missing environment values
+
+Copy the generated `.env.example` to the appropriate local environment file and supply credentials from provider projects you own. Never commit secrets.
+
+## A provider-backed journey is not ready
+
+Confirm the account, environment variables, webhook destination, database URLs or migration state, and provider dashboard configuration. Generation creates integration boundaries; it does not configure external services.
+
+## Add reports a collision
+
+Review the listed paths. The command stops rather than silently overwriting user-modified files outside its declared replacement contract.

--- a/package.json
+++ b/package.json
@@ -30,14 +30,15 @@
   "files": [
     "dist",
     "template",
+    "docs",
     "README.md",
     "LICENSE"
   ],
   "scripts": {
     "build": "tsdown",
     "dev": "tsx packages/cli/src/cli.ts",
-    "format": "prettier --write apps packages tests scripts context .agents package.json tsconfig.json pnpm-workspace.yaml README.md SECURITY.md CONTRIBUTING.md eslint.config.mjs prettier.config.mjs tsdown.config.ts vitest.config.ts vercel.json",
-    "format:check": "prettier --check apps packages tests scripts context .agents package.json tsconfig.json pnpm-workspace.yaml README.md SECURITY.md CONTRIBUTING.md eslint.config.mjs prettier.config.mjs tsdown.config.ts vitest.config.ts vercel.json",
+    "format": "prettier --write apps packages tests scripts context docs .agents package.json tsconfig.json pnpm-workspace.yaml README.md SECURITY.md CONTRIBUTING.md eslint.config.mjs prettier.config.mjs tsdown.config.ts vitest.config.ts vercel.json",
+    "format:check": "prettier --check apps packages tests scripts context docs .agents package.json tsconfig.json pnpm-workspace.yaml README.md SECURITY.md CONTRIBUTING.md eslint.config.mjs prettier.config.mjs tsdown.config.ts vitest.config.ts vercel.json",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "test": "vitest run tests/unit tests/integration",


### PR DESCRIPTION
## Summary
- establish `docs/` as the canonical Loaded Vibes end-user source
- render that Markdown directly under `/docs/*`
- document only current generator, CLI, configuration, and provider-handoff behavior

## Changes
- add the initial documentation set from the LV-205 contract
- add a small static docs renderer and navigation to the web app
- link the landing page and README to the canonical guide
- include docs in formatting and package contents
- update active execution records

## QA
- `corepack pnpm --filter @loaded-vibes/web typecheck`
- `corepack pnpm web:build` (20 static pages, including 17 docs paths)
- `corepack pnpm format:check`
- `git diff --check`

## Risks / Notes
- no CMS, unsupported provider documentation, or new validation system added

Closes #116