### PR TITLE
feat(cli): polish one-template handoff

### DIFF
--- a/.agents/execution/handoff.json
+++ b/.agents/execution/handoff.json
@@ -2,27 +2,29 @@
   "schemaVersion": 3,
   "handoff": {
     "repository": "DigitalHerencia/LoadedVibes",
-    "branch": "docs/116-end-user-docs",
-    "observedRevision": "5f9d6a0",
-    "activeIssue": 116,
-    "activeSpec": "context/specs/LV-205-end-user-docs.md",
-    "objective": "Create one canonical docs/ source for current Loaded Vibes behavior and render it under /docs without duplicating maintainer context.",
+    "branch": "feat/117-cli-package-polish",
+    "observedRevision": "19093f1",
+    "activeIssue": 117,
+    "activeSpec": "context/specs/LV-206-cli-package-polish.md",
+    "objective": "Make loaded-vibes the unambiguous canonical command and align CLI, packaging, and generated handoff language with the one-template product.",
     "readFirst": [
       "AGENTS.md",
       "context/README.md",
-      "context/specs/LV-205-end-user-docs.md",
-      "context/docs/documentation.md",
-      "context/docs/product.md",
+      "context/specs/LV-206-cli-package-polish.md",
       "context/docs/generator-cli.md",
-      "docs/index.md",
-      "apps/web/app/docs/[[...slug]]/page.tsx",
-      "apps/web/lib/docs.tsx"
+      "context/docs/release.md",
+      "context/docs/repository-transition.md",
+      ".agents/contracts/product.yaml",
+      ".agents/contracts/transition.yaml",
+      "packages/cli/src/cli.ts",
+      "packages/cli/src/create-flow.ts",
+      "package.json"
     ],
     "doNot": [
       "reintroduce DigitalHerencia/Vibes",
-      "duplicate maintainer context",
-      "document unsupported providers or commands",
-      "add a documentation CMS",
+      "claim an npm rename or publication occurred",
+      "add commands for completeness",
+      "turn doctor into a validation suite",
       "add new tests or validation systems",
       "claim checks that were not run"
     ]

--- a/.agents/execution/progress.json
+++ b/.agents/execution/progress.json
@@ -1,12 +1,12 @@
 {
   "schemaVersion": 3,
   "status": "in-progress",
-  "observedRevision": "5f9d6a0",
+  "observedRevision": "19093f1",
   "observedDate": "2026-08-09",
-  "currentOutcome": "LV-205 establishes docs/ as the canonical end-user source and renders it under /docs from the same Markdown files.",
-  "activeIssue": 116,
-  "activeSpec": "context/specs/LV-205-end-user-docs.md",
-  "openIssuesObserved": 3,
+  "currentOutcome": "LV-206 makes loaded-vibes the canonical command and aligns CLI/package handoff language with the one-template product.",
+  "activeIssue": 117,
+  "activeSpec": "context/specs/LV-206-cli-package-polish.md",
+  "openIssuesObserved": 2,
   "openPullRequestsObserved": 0,
   "completedPriorRoadmap": "LV-101 through LV-110",
   "nextRoadmap": [
@@ -36,5 +36,5 @@
     "package smoke checks",
     "deployments"
   ],
-  "nextAction": "Finish LV-205 web verification, open its focused pull request, and merge before starting LV-206."
+  "nextAction": "Finish LV-206 package verification, open its focused pull request, and merge before starting LV-207."
 }

--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
 # Loaded Vibes
 
-Loaded Vibes turns a few product choices into a recognizable SaaS starting point. It combines an enjoyable CLI, a stateless visual configurator, reproducible `loadedvibes.json` recipes, and one packaged maximal white-label application template—without asking you to redesign the stack.
+Loaded Vibes turns a bounded project configuration into a complete white-label application. It combines the canonical `loaded-vibes` CLI, a stateless visual configurator, reproducible `loadedvibes.json` contracts, and one packaged maximal template—without asking you to redesign the stack.
 
 The canonical end-user guide lives in [`docs/`](docs/index.md) and is rendered by the website under `/docs/*`. Start with [Getting started](docs/getting-started.md), then use the [configuration](docs/concepts/configuration.md) and [CLI](docs/cli/index.md) references as needed.
 
 ## Create a project
 
-Node.js 24 is required. Run the package without installing it globally:
+Node.js 24 is required. The published package is still named `create-loaded-vibes`; no npm package rename is implied. Run it without installing globally:
 
 ```powershell
 pnpm dlx create-loaded-vibes@latest create my-product
 ```
 
-The `create-loaded-vibes my-product` form remains supported for compatibility. If you install the package, the product-oriented executable is also available:
+`loaded-vibes` is the canonical command. The package also exposes `create-loaded-vibes`, including its direct `create-loaded-vibes my-product` initializer form, as a low-cost compatibility alias:
 
 ```powershell
 loaded-vibes create my-product
 ```
 
-The interactive flow asks what you are building, which supported capabilities it needs, and how it should look. For a reproducible non-interactive build:
+The interactive flow asks for a starting configuration, real optional surfaces, product identity, and visual direction. For a reproducible non-interactive build:
 
 ```powershell
 loaded-vibes create my-product --config loadedvibes.json --yes
@@ -26,9 +26,9 @@ loaded-vibes create my-product --config loadedvibes.json --yes
 
 Useful create options include `--dry-run`, `--no-git`, `--skip-install`, and `--name <package-name>`.
 
-## Choose a product shape
+## Configure generated output
 
-Presets are strong defaults over one generator—not separate application forks.
+Starting configurations are convenience defaults over one template—not separate application forks.
 
 | Preset                 | Best starting point for                                                             |
 | ---------------------- | ----------------------------------------------------------------------------------- |
@@ -77,7 +77,7 @@ loaded-vibes add sample-domain
 loaded-vibes add stripe-connect
 ```
 
-`explain` summarizes what was generated and what remains. `doctor` diagnoses actionable local/provider readiness without running the entire validation suite. `add` enables explicitly packaged compatibility projections already owned by the maximal template; it is not an arbitrary source upgrade or merge engine.
+`explain` summarizes what was generated and what remains. `doctor` diagnoses actionable local/provider readiness without running the entire validation suite. `add` enables three explicitly supported generator-owned surfaces; it is not an arbitrary source upgrade or merge engine.
 
 ## Provider handoff
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -1,6 +1,6 @@
 # CLI reference
 
-The canonical executable is `loaded-vibes`. The package also exposes `create-loaded-vibes` for initializer compatibility.
+The canonical executable is `loaded-vibes`. The published package remains `create-loaded-vibes` and also exposes that binary for initializer compatibility; no npm package rename is implied.
 
 - [`create`](/docs/cli/create) generates a project.
 - [`add`](/docs/cli/add) adds one supported owned surface.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-loaded-vibes",
   "version": "0.1.0",
-  "description": "Create an opinionated, product-shaped SaaS from the Loaded Vibes master template.",
+  "description": "Generate a complete white-label application from the Loaded Vibes master template.",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -22,7 +22,7 @@ import {
 const program = new Command();
 program
   .name('loaded-vibes')
-  .description('Generate a complete Loaded Vibes SaaS project.')
+  .description('Generate a complete white-label application from one template.')
   .version('0.1.0');
 
 interface CreateFlags {
@@ -127,24 +127,27 @@ async function runCreate(
     },
   };
   const progress = spinner();
-  if (!flags.dryRun) progress.start('Building your product foundation');
+  if (!flags.dryRun)
+    progress.start('Generating from the Loaded Vibes template');
   let result;
   try {
     result = await createProject(input, {
       dryRun: Boolean(flags.dryRun),
     });
   } catch (error) {
-    if (!flags.dryRun) progress.stop('Generation stopped');
+    if (!flags.dryRun) progress.stop('Generated output stopped');
     throw error;
   }
-  if (!flags.dryRun) progress.stop('Product foundation generated');
+  if (!flags.dryRun) progress.stop('Generated output written');
   if (result.status === 'planned') {
     outro('Dry run complete; no files were written.');
   } else if (result.status === 'accepted') {
-    outro(`Created and acceptance-validated ${recipe.name}.`);
+    outro(
+      `Created and acceptance-validated ${recipe.name}. Next: open ${target}, then run loaded-vibes doctor.`,
+    );
   } else {
     outro(
-      `Generated ${recipe.name}; install and acceptance validation were skipped.`,
+      `Generated ${recipe.name}; install and acceptance validation were skipped. Next: open ${target}, then run corepack pnpm install.`,
     );
   }
 }
@@ -159,21 +162,23 @@ attachCreateAction(
   configureCreateCommand(
     program
       .command('create')
-      .description('Create a Loaded Vibes SaaS project.'),
+      .description(
+        'Generate a white-label application from the master template.',
+      ),
   ),
 );
 
 program
   .command('add')
-  .description('Add a supported Loaded Vibes capability module.')
-  .argument('<module>', 'marketing, sample-domain, or stripe-connect')
+  .description('Add a supported generator-owned optional surface.')
+  .argument('<surface>', 'marketing, sample-domain, or stripe-connect')
   .option('--cwd <directory>', 'generated project directory', '.')
   .action(async (module: string, flags: { cwd: string }) => {
     intro('Loaded Vibes add');
     const plan = await planProjectModuleAddition(flags.cwd, module);
     console.log(
       [
-        `Module: ${plan.module}`,
+        `Optional surface: ${plan.module}`,
         `Capabilities: ${plan.addedCapabilities.join(', ')}`,
         `Prerequisites: ${plan.prerequisites.join(', ') || 'none'}`,
         `Files: ${plan.files.length} (${plan.replacements.length} intentional replacement${plan.replacements.length === 1 ? '' : 's'})`,
@@ -225,9 +230,9 @@ program
       [
         explanation.product,
         '',
-        `Preset: ${explanation.preset.label} (${explanation.preset.id})`,
+        `Starting configuration: ${explanation.preset.label} (${explanation.preset.id})`,
         `Capabilities: ${explanation.capabilities.join(', ')}`,
-        `Packaged modules: ${explanation.modules.join(', ') || 'none'}`,
+        `Added surfaces: ${explanation.modules.join(', ') || 'none'}`,
         `Design: ${explanation.design.join(', ')}`,
         '',
         'Provider boundaries',

--- a/packages/cli/src/create-flow.ts
+++ b/packages/cli/src/create-flow.ts
@@ -63,23 +63,23 @@ export const clackCreateFlowPrompts: CreateFlowPrompts = {
         {
           value: 'express',
           label: 'Express',
-          hint: 'strong defaults and a few high-leverage choices',
+          hint: 'a starting configuration and product identity',
         },
         {
           value: 'advanced',
           label: 'Advanced',
-          hint: 'all supported product and design choices',
+          hint: 'all supported surfaces, identity, and visual choices',
         },
       ],
     }) as Promise<PromptResult<SetupMode>>,
   product: () =>
     select({
-      message: 'What are you building?',
+      message: 'Choose a starting configuration',
       options: choices(productPresetIds, (id) => getProductPreset(id).label),
     }) as Promise<PromptResult<ProductPresetId>>,
   capabilities: (initial) =>
     multiselect({
-      message: 'What should the starting product include?',
+      message: 'Which optional surfaces should be included?',
       options: choices(
         optionalCapabilities,
         (id) => capabilityRegistry[id].label,
@@ -127,7 +127,7 @@ export const clackCreateFlowPrompts: CreateFlowPrompts = {
     }) as Promise<PromptResult<Design['mode']>>,
   review: (body) => note(body, 'Build review'),
   approve: () =>
-    confirm({ message: 'Generate this project?', initialValue: true }),
+    confirm({ message: 'Generate this output?', initialValue: true }),
 };
 
 function title(value: string): string {
@@ -199,10 +199,11 @@ export function formatRecipeReview(resolved: ResolvedRecipe): string {
   return [
     `${recipe.identity.displayName}`,
     '',
-    `Product: ${summary.preset.label}`,
-    `Included: ${summary.included.join(', ')}`,
-    `Not included: ${summary.excluded.join(', ') || 'None'}`,
-    `UI: ${title(recipe.design.theme)}, ${title(recipe.design.navigation)}, ${title(recipe.design.density)}, ${title(recipe.design.mode)}`,
+    `Starting configuration: ${summary.preset.label}`,
+    'Fixed foundation: TypeScript, Next.js, Prisma, Clerk, tenant authorization',
+    `Optional surfaces: ${summary.included.filter((item) => !['Organizations', 'Local roles and authorization', 'Generated project guidance'].includes(item)).join(', ') || 'None'}`,
+    `Excluded surfaces: ${summary.excluded.join(', ') || 'None'}`,
+    `Visual direction: ${title(recipe.design.theme)}, ${title(recipe.design.navigation)}, ${title(recipe.design.density)}, ${title(recipe.design.mode)}`,
   ].join('\n');
 }
 

--- a/tests/generated/real-cli.test.ts
+++ b/tests/generated/real-cli.test.ts
@@ -19,7 +19,7 @@ describe('real user-facing CLI', () => {
       '--skip-install',
     ]);
     expect(result.stdout).toContain('Build review');
-    expect(result.stdout).toContain('Bare golden app');
+    expect(result.stdout).toContain('Starting configuration: Bare golden app');
     await expect(stat(target)).rejects.toMatchObject({ code: 'ENOENT' });
   });
 
@@ -155,7 +155,7 @@ describe('real user-facing CLI', () => {
       '--cwd',
       target,
     ]);
-    expect(result.stdout).toContain('Module: marketing');
+    expect(result.stdout).toContain('Optional surface: marketing');
     expect(result.stdout).toContain('Capabilities: marketing');
     await expect(
       stat(path.join(target, 'app', '(public)', 'pricing', 'page.tsx')),
@@ -183,7 +183,7 @@ describe('real user-facing CLI', () => {
     expect(doctor.stdout).toContain('Run corepack pnpm install.');
     expect(doctor.stdout).toContain('Add the Clerk secret key to .env.local.');
     const explain = await execa('node', [cli, 'explain', '--cwd', target]);
-    expect(explain.stdout).toContain('Preset: Bare golden app');
+    expect(explain.stdout).toContain('Starting configuration: Bare golden app');
     expect(explain.stdout).toContain('Provider boundaries');
     expect(explain.stdout).toContain('Remaining setup');
   }, 15_000);

--- a/tests/unit/cli-flow.test.ts
+++ b/tests/unit/cli-flow.test.ts
@@ -82,8 +82,9 @@ describe('CLI product flow', () => {
     const review = formatRecipeReview(
       resolveRecipe({ name: 'review-app', product: 'client-portal' }),
     );
-    expect(review).toContain('Included:');
-    expect(review).toContain('Not included:');
+    expect(review).toContain('Fixed foundation:');
+    expect(review).toContain('Optional surfaces:');
+    expect(review).toContain('Excluded surfaces:');
     expect(review).toContain('Client portal');
   });
 });


### PR DESCRIPTION
## Summary
- make `loaded-vibes` the unambiguous canonical product command
- align CLI prompts, review, and handoff output with the one-template model
- document the still-published `create-loaded-vibes` package/compatibility alias without claiming a rename

## Changes
- use fixed-foundation, optional-surface, visual-direction, and generated-output vocabulary
- improve create/add/explain descriptions and generated-project next steps
- update package description, README, CLI docs, and existing output assertions
- retain both bins because the compatibility alias is cheap and prevents initializer breakage
- confirm package contents use `template/` and include canonical docs

## QA
- `corepack pnpm typecheck`
- `corepack pnpm exec vitest run tests/unit/cli-flow.test.ts` (3 passed)
- `corepack pnpm release:check` (471 safe tarball entries; packed canonical create smoke passed)
- `corepack pnpm build`
- `corepack pnpm exec vitest run tests/generated/real-cli.test.ts` (8 passed)
- `git diff --check`

## Risks / Notes
- no npm publication or package rename performed

Closes #117