### PR TITLE
docs: add llms.txt repository guide

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,90 @@
+# Loaded Vibes
+
+> Loaded Vibes is an opinionated developer tool and deterministic generator that turns a bounded project configuration into a complete white-label Hipster Stack application from one repository-owned maximal template.
+
+Use `context/docs/*.md` for active product and architecture source-of-truth contracts, `docs/` for canonical end-user guidance, and `AGENTS.md` for repository authority and agent workflow. The live repository is organized around `packages/schema` for the shared configuration contract, `packages/core` for deterministic resolution and generation, `packages/cli` for terminal UX, `apps/web` for the stateless website/configurator, and `template/` as the sole executable application source.
+
+The CLI, web configurator, and `loadedvibes.json` share one configuration model. Generated projects preserve the repository's fixed Hipster Stack foundation; configuration is limited to choices the template and generator can honor deterministically.
+
+## Documentation
+
+- [Repository README](README.md): Primary project overview, CLI usage, configurator behavior, generated output, provider handoff, and repository development commands.
+- [Context Index](context/README.md): Maintainer context map and guidance for locating product, architecture, specification, and governance material.
+- [Product Definition](context/docs/product.md): Authoritative product purpose, user, value, surfaces, fixed foundation, configurable scope, non-goals, and system relationships.
+- [Repository and Generator Architecture](context/docs/architecture.md): Authoritative repository topology, package boundaries, one-template generation model, application grammar, provenance, and safety rules.
+- [Configuration Model](context/docs/configuration.md): Authoritative shared configuration semantics, supported choice categories, presets, and configuration-honesty rules.
+- [Generator and CLI Contract](context/docs/generator-cli.md): Maintainer contract for generation behavior and the CLI execution surface.
+- [Master Template Contract](context/docs/template.md): Maintainer contract for the repository-owned maximal application template and its ownership boundaries.
+- [Web Surface Contract](context/docs/web.md): Maintainer contract for the developer website, visual configurator, previews, and stateless behavior.
+- [Documentation Contract](context/docs/documentation.md): Maintainer contract for canonical end-user documentation and website documentation rendering.
+
+## End-User Guides
+
+- [Documentation Index](docs/index.md): Canonical end-user documentation entry point.
+- [Getting Started](docs/getting-started.md): Installation and first-project workflow.
+- [Configuration Concept](docs/concepts/configuration.md): User-facing explanation of the shared configuration model.
+- [One-Template Concept](docs/concepts/one-template.md): User-facing explanation of the single maximal-template generation model.
+- [Generated Project Concept](docs/concepts/generated-project.md): What a generated project is and which responsibilities remain with the developer.
+- [CLI Reference](docs/cli/index.md): Index of supported CLI commands.
+- [Create Command](docs/cli/create.md): Generate a project from interactive or reproducible configuration.
+- [Add Command](docs/cli/add.md): Add explicitly supported generator-owned surfaces to an existing generated project.
+- [Doctor Command](docs/cli/doctor.md): Diagnose actionable local and provider readiness.
+- [Explain Command](docs/cli/explain.md): Explain generated provenance and configuration state.
+- [Project Configuration](docs/configuration/project.md): User-facing project and destination configuration options.
+- [Identity Configuration](docs/configuration/identity.md): Product identity configuration options.
+- [Integration Configuration](docs/configuration/integrations.md): Supported provider integration configuration.
+- [Optional Surfaces](docs/configuration/optional-surfaces.md): Supported optional application surfaces and dependency behavior.
+- [Design Configuration](docs/configuration/design.md): Supported semantic visual-direction configuration.
+
+## Specifications
+
+- [Specification Index](context/specs/README.md): Completed issue-sized roadmap, dependency order, and verification rule for the one-template repository migration.
+- [LV-201 Master Template Consolidation](context/specs/LV-201-consolidate-master-template.md): Scope and acceptance context for consolidating one repository-owned master template.
+- [LV-202 Configuration Core Simplification](context/specs/LV-202-simplify-configuration-core.md): Scope and acceptance context for simplifying configuration and ownership semantics.
+- [LV-203 One-Template Generator](context/specs/LV-203-one-template-generator.md): Scope and acceptance context for deterministic retain/remove generation from one template.
+- [LV-204 Web Landing and Configurator](context/specs/LV-204-web-landing-configurator.md): Scope and acceptance context for the website and visual configurator.
+- [LV-205 End-User Documentation](context/specs/LV-205-end-user-docs.md): Scope and acceptance context for canonical user documentation and `/docs`.
+- [LV-206 CLI and Package Polish](context/specs/LV-206-cli-package-polish.md): Scope and acceptance context for the final CLI and package model.
+- [LV-207 Cleanup and Release](context/specs/LV-207-cleanup-release.md): Scope and acceptance context for migration cleanup and release coherence.
+
+## Core Implementation
+
+- [Shared Configuration Schema](packages/schema/src/recipe.ts): Zod-backed public configuration shapes and enums shared by CLI, core, and web surfaces.
+- [Core Public API](packages/core/src/index.ts): Main exports for the deterministic generator core.
+- [Capability Catalog](packages/core/src/capabilities.ts): Supported configurable capabilities and their relationships.
+- [Template Ownership Model](packages/core/src/ownership.ts): Ownership metadata used to retain or remove generator-owned template material.
+- [Generated Manifest](packages/core/src/manifest.ts): Provenance representation for generated projects.
+- [CLI Entry Point](packages/cli/src/cli.ts): Command parsing and terminal execution surface.
+- [Create Flow](packages/cli/src/create-flow.ts): Interactive and configuration-driven project creation flow.
+- [Web Package](apps/web/package.json): Dependencies and scripts for the stateless website and configurator application.
+
+## Master Template
+
+- [Template README](template/README.md): Architecture, stack, route map, RBAC model, provider boundaries, validation, and operating guidance for the generated application foundation.
+- [Template Metadata](template/.loaded-vibes-template.json): Repository-owned metadata identifying the canonical master template.
+- [Template Environment Example](template/.env.example): Provider and application environment variables expected by generated projects.
+- [Template Agent Guidance](template/AGENTS.md): Source precedence and working constraints inherited by the master application source.
+
+## Repository Configuration
+
+- [Root Package Manifest](package.json): Published package identity, binaries, scripts, toolchain requirements, dependencies, and packaged files.
+- [pnpm Workspace](pnpm-workspace.yaml): Monorepo workspace boundaries.
+- [Turbo Configuration](turbo.json): Monorepo task orchestration configuration.
+- [TypeScript Base Configuration](tsconfig.base.json): Shared TypeScript compiler defaults for repository packages and applications.
+
+## Governance
+
+- [Repository Agent Governance](AGENTS.md): Authority hierarchy, task-specific reading order, product model, fixed foundation, repository target, working rules, and delivery process.
+- [Context Agent Guidance](context/AGENTS.md): Scoped instructions for modifying maintainer product, architecture, and specification context.
+- [Product Machine Contract](.agents/contracts/product.yaml): Compact machine-readable product boundaries derived from controlling documentation.
+- [Architecture Machine Contract](.agents/contracts/architecture.yaml): Compact machine-readable repository and generator architecture boundaries.
+- [Transition Machine Contract](.agents/contracts/transition.yaml): Compact machine-readable migration and repository-transition boundaries.
+- [Security Policy](SECURITY.md): Repository security expectations and vulnerability-reporting guidance.
+- [Contributing Guide](CONTRIBUTING.md): Contributor workflow and repository contribution expectations.
+
+## Optional
+
+- [Repository Transition](context/docs/repository-transition.md): Historical transition rules and constraints for moving from migration-era topology to the current one-template repository shape.
+- [Release Contract](context/docs/release.md): Maintainer release and cleanup guidance.
+- [Troubleshooting](docs/troubleshooting.md): End-user fixes for common local generation and provider-readiness problems.
+- [Changelog](CHANGELOG.md): Historical release and repository change record.

--- a/llms.txt
+++ b/llms.txt
@@ -69,8 +69,10 @@ The CLI, web configurator, and `loadedvibes.json` share one configuration model.
 
 - [Root Package Manifest](package.json): Published package identity, binaries, scripts, toolchain requirements, dependencies, and packaged files.
 - [pnpm Workspace](pnpm-workspace.yaml): Monorepo workspace boundaries.
-- [Turbo Configuration](turbo.json): Monorepo task orchestration configuration.
-- [TypeScript Base Configuration](tsconfig.base.json): Shared TypeScript compiler defaults for repository packages and applications.
+- [TypeScript Configuration](tsconfig.json): Repository TypeScript compiler settings and workspace source coverage.
+- [Package Build Configuration](tsdown.config.ts): Build configuration for the published CLI package.
+- [Web Deployment Configuration](vercel.json): Vercel build and deployment settings for the repository web surface.
+- [Test Configuration](vitest.config.ts): Vitest configuration for repository unit, integration, and generated-project tests.
 
 ## Governance
 
@@ -87,4 +89,3 @@ The CLI, web configurator, and `loadedvibes.json` share one configuration model.
 - [Repository Transition](context/docs/repository-transition.md): Historical transition rules and constraints for moving from migration-era topology to the current one-template repository shape.
 - [Release Contract](context/docs/release.md): Maintainer release and cleanup guidance.
 - [Troubleshooting](docs/troubleshooting.md): End-user fixes for common local generation and provider-readiness problems.
-- [Changelog](CHANGELOG.md): Historical release and repository change record.


### PR DESCRIPTION
Closes #126

## Summary
- add a root `llms.txt` following the official llms.txt Markdown structure
- prioritize active product/architecture source-of-truth documentation and canonical end-user guides
- map current `packages/schema`, `packages/core`, `packages/cli`, `apps/web`, and `template/` implementation surfaces
- include governance and machine contracts with completed migration/release context kept lower priority

## Validation
- read back the final file from the branch
- checked every linked path through current repository directory listings
- removed stale candidate links found during validation (`turbo.json`, `tsconfig.base.json`, `CHANGELOG.md`)
- compared structure against the official llms.txt specification

No runtime code changed; full application validation is not necessary for this documentation-only change.