### PR TITLE
governance: define mockup-driven web refresh

### DIFF
--- a/.agents/contracts/product.yaml
+++ b/.agents/contracts/product.yaml
@@ -1,4 +1,4 @@
-schema_version: 3
+schema_version: 4
 id: loaded-vibes.product
 authority: machine-contract
 sources:
@@ -22,8 +22,9 @@ surfaces:
   - shared-configuration
   - generator-core
   - cli
-  - web-landing
-  - web-configurator
+  - web-product
+  - web-libraries
+  - web-builder
   - end-user-docs
   - loadedvibes-json
   - generated-application
@@ -37,10 +38,22 @@ web:
   requires_auth: false
   requires_database: false
   hosted_generation_required: false
+  visual_acceptance: mockup-driven
   routes:
-    landing: /
-    configure: /configure
+    product: /
+    libraries: /libraries
+    library_detail: /libraries/[slug]
+    builder: /configure
     docs: /docs
+  navigation:
+    - Product
+    - Libraries
+    - Docs
+    - Builder
+  semantics:
+    mockups_control_presentation: true
+    shared_core_controls_configuration: true
+    fixed_foundation_is_read_only: true
 
 template:
   count: 1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Loaded Vibes Governance Directory
 
-Loaded Vibes is a developer-focused software factory: one repository-owned maximal white-label Hipster Stack template, one deterministic generation engine, one shared configuration contract, a CLI execution surface, a stateless visual configurator, and end-user documentation.
+Loaded Vibes is a developer-focused software factory: one repository-owned maximal white-label Hipster Stack template, one deterministic generation engine, one shared configuration contract, a CLI execution surface, a stateless visual Builder, browsable product Libraries, and end-user documentation.
 
 This file is the governance directory. Read only the material relevant to the work in front of you.
 
@@ -29,6 +29,8 @@ Read:
 5. only the `.agents/contracts/*` files named by that spec;
 6. the actual files being changed.
 
+Do not inventory the entire repository again once the active spec identifies the relevant surface. Expand context only when an actual import, contract, failing check, or acceptance criterion requires it.
+
 ### Master template work
 
 Read:
@@ -54,10 +56,15 @@ Read:
 
 Read:
 
-- `context/docs/web.md`
-- `context/docs/product.md`
-- the relevant web spec
-- `.agents/contracts/product.yaml`
+- the matching web spec first;
+- `context/docs/web.md`;
+- `context/docs/product.md` only when the spec names it;
+- `context/docs/configuration.md` only when changing Builder semantics;
+- `.agents/contracts/product.yaml`;
+- the local `context/mockups/` subject named by the spec;
+- only the affected `apps/web` files plus directly imported core/schema files needed to verify semantics.
+
+`context/docs/web.md` already reconciles the applicable Codependent Coding / Loaded Vibes presentation and layer rules for this website. Do not repeatedly crawl CodependentCoding, DevNotes, `template/`, or unrelated generator internals during each visual Issue unless a concrete contradiction or missing semantic requires it.
 
 ### End-user documentation work
 
@@ -88,7 +95,7 @@ repository-owned maximal template
         ├──────────────┐
         │              │
         ▼              ▼
-shared config      website configurator
+shared config      website Builder
 schema/core             │
         │               │
         ├──────┬────────┘
@@ -183,7 +190,9 @@ LoadedVibes/
 
 - Work one GitHub Issue/spec at a time.
 - Make the smallest complete change that reaches the Issue outcome.
+- Treat current mockups as visual acceptance artifacts where the active web spec says so; reproduce their design faithfully while adapting literal labels/content only when required for truthful product behavior.
 - Preserve working code unless the Issue explicitly requires changing its ownership or location.
+- Delete replaced UI/CSS/helpers after their last caller is gone; do not leave parallel old/new implementations.
 - Do not redesign the Hipster Stack doctrine inside this repo.
 - Do not invent modules, providers, routes, or architecture that the repository does not support.
 - Do not create a generic framework generator, provider marketplace, hosted control plane, or enterprise governance product.
@@ -192,8 +201,8 @@ LoadedVibes/
 - Never claim a check ran if it did not.
 - Never collect, print, copy, or commit provider secrets.
 - Keep Windows/PowerShell first-class.
-- Keep the web configurator stateless unless a future product decision explicitly changes that.
-- Keep the CLI and web configurator as adapters over the same core configuration semantics.
+- Keep the web Builder stateless unless a future product decision explicitly changes that.
+- Keep the CLI and web Builder as adapters over the same core configuration semantics.
 - Do not reintroduce `DigitalHerencia/Vibes` as an upstream, source, sync target, reference dependency, or provenance dependency.
 
 ## Delivery

--- a/context/README.md
+++ b/context/README.md
@@ -1,39 +1,43 @@
 # Loaded Vibes Context
 
-This directory tells Codex what Loaded Vibes is, what the repository is becoming, and how to finish the current migration without losing the working generator.
+This directory tells Codex what Loaded Vibes is, which contracts control the repository, and what active work remains.
 
 ## Product definition
 
-Loaded Vibes is an opinionated project initializer and deterministic software-production tool for modern TypeScript web applications built on the Hipster Stack.
+Loaded Vibes is an opinionated project initializer and deterministic software-production tool for modern TypeScript web applications built on the Hipster Stack and Loaded Vibes WebApp Architecture.
 
-Its value is the generated repository: a polished, white-label application that already contains the recurring architecture, integration boundaries, project structure, and implementation context the builder would otherwise recreate by hand.
+Its value is the generated repository: a polished white-label application that already contains the recurring architecture, integration boundaries, project structure, and implementation context the builder would otherwise recreate by hand.
 
-The CLI is the primary execution surface. The web app is a developer-oriented landing page, visual configuration workbench, and documentation surface. `loadedvibes.json` is the reproducible configuration handoff.
+The CLI is the primary execution surface. The web app presents the Product, browsable Libraries/building blocks, the stateless Builder, and canonical end-user Docs. `loadedvibes.json` is the reproducible configuration handoff.
 
-## Current transition
+## Current state
 
-The repository owns its maximal application foundation at `template/` and has no external template authority. Core-owned configuration now resolves explicit retain/remove ownership over that one source. The remaining cleanup is product-facing:
+The one-template repository migration is complete. The active work is a bounded replacement of the existing website UI/UX using local mockups while preserving the working generator and shared configuration semantics.
 
 ```text
-CURRENT MIGRATION SHAPE
-apps/web
+WORKING PRODUCT
 packages/{cli,core,schema}
-template/ + core ownership catalog
-legacy product-preset/module concepts
-
-              ↓
-
-TARGET SHAPE
-apps/web
-packages/{cli,core,schema}
+        +
 template/
+        +
 docs/
-one technical configuration model
-one deterministic generator
-one CLI
+        +
+apps/web current UI
+
+              ↓ LV-208..LV-210 only
+
+TARGET WEB SURFACE
+Product      /
+Libraries    /libraries/*
+Builder      /configure
+Docs         /docs/*
+
+same shared schema/core
+same one-template generator
+same CLI handoff
 ```
 
-Do not throw away working implementation merely to reach the target tree. Follow the active specs in order so ownership moves before old structures disappear.
+Do not reopen the completed generator migration during the UI refresh. Follow LV-208 through LV-210 in order and change non-web code only when a concrete existing contract requires it.
 
 ## Source map
 
@@ -49,8 +53,9 @@ Do not throw away working implementation merely to reach the target tree. Follow
 
 - `context/docs/web.md`
 - `context/docs/documentation.md`
+- local `context/mockups/` visual acceptance inputs for active web Issues
 
-### Migration and shipping
+### Release and repository history
 
 - `context/docs/repository-transition.md`
 - `context/docs/release.md`
@@ -58,7 +63,8 @@ Do not throw away working implementation merely to reach the target tree. Follow
 ### Implementation roadmap
 
 - `context/specs/README.md`
-- `context/specs/LV-201-*.md` through `LV-207-*.md`
+- completed `LV-201` through `LV-207`
+- active `LV-208` through `LV-210`
 
 ### Machine-readable boundaries
 
@@ -66,16 +72,18 @@ Do not throw away working implementation merely to reach the target tree. Follow
 - `.agents/contracts/architecture.yaml`
 - `.agents/contracts/transition.yaml`
 
-## External authority
+## Engineering doctrine
 
-DevNotes owns canonical Hipster Stack engineering doctrine, including the architectural grammar summarized as:
+DevNotes owns canonical Hipster Stack engineering doctrine. The Codependent Coding knowledge system formalizes the same Loaded Vibes WebApp Architecture, layer contracts, technology ownership, and agent-execution method used to build applications.
 
-> Routes adapt. Features orchestrate. Components render. Fetchers read. Actions receive mutations. Schemas validate. Workflows coordinate use cases. Authorization decides. Transactions preserve database invariants. Integration adapters own provider mechanics. Webhooks reconcile external truth.
+The applicable grammar is summarized as:
 
-Loaded Vibes owns the executable template that embodies that doctrine.
+> Routes adapt. Features orchestrate. Components render. Fetchers read. Actions write. Schemas validate. Authorization decides. Transactions preserve invariants. Webhooks reconcile external truth.
 
-Codependent Coding is a downstream adaptive implementation system. It is not part of Loaded Vibes generation.
+For the mostly static Loaded Vibes website surfaces, apply that doctrine proportionally. Use thin App Router routes, server-first presentation composition, and the existing client-side Builder only where local interaction is required. Do not manufacture fetchers/actions/workflows for static content merely to make the directory tree look architectural.
+
+Loaded Vibes owns the executable template and repository-local product behavior. Codependent Coding and DevNotes are doctrine/knowledge authorities, not runtime dependencies.
 
 ## Working rule
 
-The roadmap exists to finish and ship a useful generator/CLI/template. Governance should reduce ambiguity and repetitive work, not create a second project beside the product.
+The active roadmap exists to make the real product look and operate like the approved mockups with the fewest correct edits. Governance should reduce ambiguity and token use, not create a second project beside the product.

--- a/context/docs/architecture.md
+++ b/context/docs/architecture.md
@@ -13,7 +13,7 @@ authority: source-of-truth
 Loaded Vibes is a deterministic compiler from a bounded configuration to a filtered and personalized copy of one maximal application template.
 
 ```text
-Web Configurator ─┐
+Web Builder ───────┐
 CLI ──────────────┼──> shared schema + normalization
 loadedvibes.json ─┘                │
                                    ▼
@@ -43,14 +43,14 @@ loadedvibes.json ─┘                │
 ```text
 /
 ├── apps/
-│   └── web/                 # landing + /configure + /docs
+│   └── web/                 # / + /libraries/* + /configure + /docs/*
 ├── packages/
 │   ├── cli/                 # terminal UX and command adapters
 │   ├── core/                # resolution, planning, generation
 │   └── schema/              # shared loadedvibes.json contract
 ├── template/                # one maximal white-label application
 ├── docs/                    # canonical end-user docs
-├── context/                 # maintainer/Codex context
+├── context/                 # maintainer/Codex context and visual acceptance inputs
 ├── .agents/                 # compact machine contracts and execution state
 ├── scripts/                 # package/release utilities actually used
 ├── .github/
@@ -105,13 +105,16 @@ It must not create a second configuration interpretation.
 
 Owns:
 
-- the Loaded Vibes developer website;
-- the visual configuration workbench;
-- representative preview;
-- rendering end-user documentation;
-- exporting/copying a configuration or CLI handoff.
+- the Loaded Vibes Product landing page;
+- the Libraries catalog and library detail presentation metadata;
+- the stateless Builder configuration workbench;
+- a readable preview of normalized/resolved Builder output;
+- rendering canonical end-user documentation;
+- exporting/copying configuration and CLI handoff.
 
-The initial web app remains stateless and does not generate projects on a hosted server.
+`apps/web` may classify and describe product building blocks for navigation, but it must not duplicate core capability dependencies, fixed/configurable semantics, preset resolution, or recipe validation into a second rules engine.
+
+The web app remains stateless and does not generate projects on a hosted server.
 
 ### `template/`
 

--- a/context/docs/product.md
+++ b/context/docs/product.md
@@ -28,7 +28,7 @@ The product should assume familiarity with tools such as Next.js, Prisma, Clerk,
 
 The success metric is the amount of repetitive project setup and foundational implementation the generated repository removes.
 
-The configurator being attractive matters. The CLI being pleasant matters. The decisive payoff is:
+The Builder being attractive matters. The CLI being pleasant matters. The decisive payoff is:
 
 > How much useful, correct application did the user receive before writing product-specific code?
 
@@ -38,9 +38,12 @@ The configurator being attractive matters. The CLI being pleasant matters. The d
 2. **Configuration contract** — the bounded project choices Loaded Vibes can actually honor.
 3. **Core generator** — deterministic resolution, retain/remove ownership, transforms, materialization, and provenance.
 4. **CLI** — primary execution surface.
-5. **Web app** — developer-oriented landing page, visual configurator, and end-user docs.
-6. **`loadedvibes.json`** — portable configuration handoff.
-7. **Generated application** — the actual product value.
+5. **Web Product page** — concise explanation and entry point at `/`.
+6. **Web Libraries** — browsable catalog and detail pages for Loaded Vibes building blocks at `/libraries/*`.
+7. **Web Builder** — stateless visual configuration workbench at `/configure`.
+8. **End-user docs** — canonical `docs/` content rendered under `/docs/*`.
+9. **`loadedvibes.json`** — portable configuration handoff.
+10. **Generated application** — the actual product value.
 
 ## Fixed foundation
 
@@ -88,6 +91,8 @@ Useful configuration categories include:
 - semantic visual direction.
 
 Presets may remain as convenience defaults if useful, but they are not separate templates and they are not the center of the product.
+
+The Libraries and Builder web surfaces may explain fixed foundation choices, but fixed choices must remain read-only rather than becoming decorative configuration.
 
 ## Non-goals
 

--- a/context/docs/web.md
+++ b/context/docs/web.md
@@ -15,7 +15,7 @@ The web app presents Loaded Vibes as a coherent developer product and gives user
 It has four jobs:
 
 1. explain the product concisely;
-2. expose the Loaded Vibes system as browsable libraries/capabilities;
+2. expose the Loaded Vibes system as browsable libraries/building blocks;
 3. let users compose a supported configuration visually;
 4. render the canonical end-user documentation from `docs/`.
 
@@ -25,38 +25,52 @@ It is not a hosted project-control product, generic stack marketplace, or market
 
 ```text
 /                    Product / landing page
-/libraries           library/capability catalog
-/libraries/[slug]    individual library/capability detail
+/libraries           library/building-block catalog
+/libraries/[slug]    individual library/building-block detail
 /docs/*              end-user Loaded Vibes documentation
 /configure            Builder visual configuration workbench
 ```
 
-The primary navigation labels are:
+Primary navigation:
 
 ```text
 Product | Libraries | Docs | Builder
 ```
 
-`Builder` links to `/configure`; the route does not need to be renamed merely to match the navigation label.
+`Builder` links to `/configure`; do not rename a working route merely to make the URL literal.
 
 No Loaded Vibes account system, hosted project database, Loaded Vibes billing system, or remote build backend is required.
 
-## Current visual acceptance inputs
+## Visual acceptance contract
 
-The current web replacement work is mockup-driven. When the following files are present in the implementation working tree, they are the visual acceptance artifacts for LV-208 through LV-210:
+The current web replacement is mockup-driven. The implementation working tree contains a local `context/mockups/` directory with four visual subjects:
 
-```text
-context/mockups/landing.png
-context/mockups/libraries.png
-context/mockups/config.png
-context/mockups/builder.png
-```
+- Product/landing page;
+- Libraries catalog;
+- individual library/configuration detail page;
+- Builder.
 
-Do not reinterpret these mockups into a different aesthetic or generic SaaS design. Match their hierarchy, density, spacing, dark surfaces, border treatment, typography scale, navigation, card composition, restrained glow, and Digital Herencia/Loaded Vibes brand placement as faithfully as practical across responsive layouts.
+Codex must inspect that directory and map the actual files by their visual content before editing. Do not assume filenames and do not continue if the required mockup subject is missing.
 
-The mockups are presentation authority, not permission to invent unsupported product semantics. If placeholder text, toggles, providers, or JSON in a mockup conflict with the shared schema/core, keep the visual treatment and bind it to real repository-supported behavior instead.
+The mockups are the design standard. Faithfully reproduce their:
 
-If a required mockup is absent from the working tree, stop rather than guessing its visual content.
+- page structure and section order;
+- visual hierarchy and information density;
+- spacing and proportions;
+- dark surfaces and border treatment;
+- typography scale and emphasis;
+- navigation placement;
+- card composition;
+- restrained teal/cyan glow;
+- Loaded Vibes and Digital Herencia brand placement;
+- desert/circuit footer treatment;
+- interaction model implied by controls and links.
+
+Do not reinterpret them into another aesthetic, generic SaaS template, or personal redesign.
+
+The mockups are **presentation authority, not semantic authority**. Apply product judgment when literal text or controls would contradict the real product. Button/control labels, JSON examples, category wording, and link targets may be adjusted to describe actual Loaded Vibes behavior. Preserve the depicted design and interaction purpose while replacing illustrative nonsense with the correct repository-supported action.
+
+Never implement a fake toggle, fake provider choice, fake recipe field, or fake output merely because it appears illustratively in a mockup. Shared schema/core and current repository behavior remain authoritative for functionality.
 
 ## Brand and visual direction
 
@@ -77,11 +91,43 @@ Use the established brand family:
 
 Avoid violet/magenta-heavy styling, beige editorial styling, startup-confetti aesthetics, excessive gradients, partner grids, decorative dashboard density, and marketing sections that do not improve product comprehension.
 
-Preserve the repository-root `public/` brand assets. Website implementation may import or otherwise consume them through the smallest build-compatible approach, but must not delete that directory or its source images.
+Preserve the repository-root `public/` brand assets and their source images. The website may consume them through the smallest build-compatible approach, but must not delete that directory merely because the Next.js app lives under `apps/web`.
+
+## Architecture and implementation method
+
+The UI replacement must remain recognizably built according to the Codependent Coding knowledge system, Hipster Stack, and Loaded Vibes WebApp Architecture. The canonical architectural grammar is:
+
+```text
+Routes adapt.
+Features orchestrate.
+Components render.
+Fetchers read.
+Actions write.
+Schemas validate.
+Authorization decides.
+Transactions preserve invariants.
+Webhooks reconcile external truth.
+```
+
+For these mostly static/product-presentation surfaces, use the applicable subset rather than ceremonial layers:
+
+```text
+route/page -> feature/presentation orchestration -> shared/domain presentation
+```
+
+- keep App Router pages/layouts thin;
+- default to Server Components;
+- create a client boundary only where browser interaction/local state requires one, chiefly Builder;
+- keep pure presentation free of protected I/O, provider SDKs, Prisma, or product authority;
+- reuse the existing browser-safe `@loaded-vibes/core` contract for Builder semantics;
+- do not add fetchers/actions/workflows when the page has no protected read or mutation just to satisfy a diagram;
+- do not turn a focused website refactor into a repository-wide architecture migration.
+
+Relevant doctrine sources are the Codependent Coding knowledge system (`docs/10-loaded-vibes-architecture.md`, `docs/11-hipster-stack-tech-map.md`, `docs/12-layer-contracts.md`, `docs/18-agent-execution.md`) and the mirrored canonical Loaded Vibes architecture source in DevNotes. Local repository governance controls when it is more specific.
 
 ## Product landing page
 
-The landing page follows `context/mockups/landing.png` and should communicate, with minimal copy:
+The landing mockup should communicate with minimal copy:
 
 - Loaded Vibes generates a serious production-minded SaaS starting point;
 - the user chooses bounded product/configuration differences rather than architecture;
@@ -94,26 +140,28 @@ The hero/product preview may summarize Builder state, but must not expose fake p
 
 ## Libraries
 
-`/libraries` is a browsable product-building-block catalog, not a package registry.
+`/libraries` is a browsable product-building-block catalog, not a package registry and not a generic technology catalog.
 
-The mockup groups concepts under a small number of categories such as Foundation, Identity, Data, Revenue, and Interface. Presentation metadata may be web-owned, but configuration truth must come from existing repository sources where available:
+The visual mockup groups concepts under a small number of categories such as Foundation, Identity, Data, Revenue, and Interface. The actual concepts and descriptions must represent the way Loaded Vibes applications are built under the Loaded Vibes architecture and Hipster Stack.
+
+Presentation metadata may be web-owned, but configuration truth comes from existing repository sources where available:
 
 - `packages/core/src/capabilities.ts` for capability labels, dependencies, and fixed/configurable status;
 - `packages/core/src/presets.ts` for real product presets;
 - `packages/schema/src/recipe.ts` for valid recipe fields;
-- the fixed-foundation governance for non-configurable architectural elements.
+- Loaded Vibes fixed-foundation governance for non-configurable architectural elements.
 
 Do not duplicate dependency/fixed semantics in a second web-only rules engine.
 
-Individual library pages should make configuration/status the primary useful content. A configurable capability may show the smallest valid `loadedvibes.json` example needed to enable it. A fixed-foundation library must be identified as fixed/included rather than exposing a decorative toggle or fake provider selector. Related-library links are presentation/navigation metadata only.
+Individual library pages make configuration/status the primary useful content. A configurable capability may show the smallest valid `loadedvibes.json` example needed to enable it. A fixed-foundation library must be identified as fixed/included rather than exposing a decorative toggle or fake provider selector. Related-library links are presentation/navigation metadata only.
 
 ## Builder
 
 `/configure` is the Builder.
 
-The Builder follows `context/mockups/builder.png`: a compact configuration panel paired with a readable recipe/result preview. It should feel like composing a supported starting point, not completing a long wizard.
+The Builder follows the Builder mockup: a compact configuration surface paired with a readable recipe/result preview. It should feel like composing a supported Loaded Vibes starting point, not completing a long wizard and not shopping for architecture.
 
-The Builder must preserve the existing stateless capabilities that are still product-valid:
+Preserve existing stateless product-valid behavior:
 
 - shared schema/core resolution;
 - real product presets;
@@ -126,7 +174,7 @@ The Builder must preserve the existing stateless capabilities that are still pro
 
 Fixed architecture and fixed capabilities may be shown as read-only selected/included items for comprehension, but never as user-switchable choices.
 
-The configuration/result panel should show actual normalized configuration and resolved inclusions. A representative generated-app preview is optional and should be removed if it no longer serves the mockup-driven Builder experience or duplicates the recipe/result preview.
+The result panel must show actual normalized configuration and resolved inclusions. A representative generated-app preview may be removed when it duplicates the mockup-driven recipe/result experience and no longer adds product value.
 
 ## Docs
 
@@ -149,8 +197,9 @@ It does not perform local generation on the hosted website.
 
 For the mockup replacement:
 
-- prefer refactoring/reusing the current app routes, shared config helpers, and browser-safe core;
-- introduce only shared components that remove real duplication across the mocked pages;
-- delete obsolete CSS/components/helpers after their final caller is removed;
-- do not add a UI framework, icon package, animation library, design-token system, or new validation harness merely to reproduce the mockups;
-- use the existing web typecheck/build and only narrowly relevant repository checks.
+- inspect first, then make the smallest complete refactor;
+- prefer reusing current routes, config helpers, and browser-safe core;
+- introduce only shared components that remove real duplication or enforce the established presentation hierarchy;
+- delete obsolete CSS/components/helpers immediately after their final caller is replaced;
+- do not add a UI framework, icon package, animation library, design-token subsystem, backend, or new validation harness merely to reproduce the mockups;
+- run only the existing web checks that directly establish the changed behavior.

--- a/context/docs/web.md
+++ b/context/docs/web.md
@@ -10,99 +10,147 @@ authority: source-of-truth
 
 ## Product role
 
-The website is a developer tool with enough explanation to establish what Loaded Vibes does.
+The web app presents Loaded Vibes as a coherent developer product and gives users a stateless visual configuration surface over the same configuration contract used by the CLI.
 
-It is not a marketing site with a configurator buried at the bottom.
+It has four jobs:
 
-Target balance:
+1. explain the product concisely;
+2. expose the Loaded Vibes system as browsable libraries/capabilities;
+3. let users compose a supported configuration visually;
+4. render the canonical end-user documentation from `docs/`.
+
+It is not a hosted project-control product, generic stack marketplace, or marketing site that invents choices the generator cannot honor.
+
+## Routes and navigation
 
 ```text
-roughly 20% explanation
-roughly 80% tool
+/                    Product / landing page
+/libraries           library/capability catalog
+/libraries/[slug]    individual library/capability detail
+/docs/*              end-user Loaded Vibes documentation
+/configure            Builder visual configuration workbench
 ```
 
-## Routes
+The primary navigation labels are:
 
 ```text
-/             developer-oriented landing page
-/configure    visual configuration workbench
-/docs/*       end-user Loaded Vibes documentation
+Product | Libraries | Docs | Builder
 ```
 
-No Loaded Vibes account system, hosted project database, billing system, or remote build backend is required.
+`Builder` links to `/configure`; the route does not need to be renamed merely to match the navigation label.
 
-## Landing page
+No Loaded Vibes account system, hosted project database, Loaded Vibes billing system, or remote build backend is required.
 
-The landing page should communicate:
+## Current visual acceptance inputs
 
-- Loaded Vibes is a software factory / deterministic project generator;
-- one template, not many architectures;
-- DevNotes supplies doctrine and Loaded Vibes supplies deterministic production;
-- the generated white-label repo is the payoff;
-- the CLI is the execution surface;
-- the configurator creates a portable configuration for the CLI.
+The current web replacement work is mockup-driven. When the following files are present in the implementation working tree, they are the visual acceptance artifacts for LV-208 through LV-210:
 
-Keep it concise and developer-facing.
+```text
+context/mockups/landing.png
+context/mockups/libraries.png
+context/mockups/config.png
+context/mockups/builder.png
+```
 
-## Visual direction
+Do not reinterpret these mockups into a different aesthetic or generic SaaS design. Match their hierarchy, density, spacing, dark surfaces, border treatment, typography scale, navigation, card composition, restrained glow, and Digital Herencia/Loaded Vibes brand placement as faithfully as practical across responsive layouts.
 
-Use the supplied Loaded Vibes concept imagery as the visual direction, not as a literal layout specification.
+The mockups are presentation authority, not permission to invent unsupported product semantics. If placeholder text, toggles, providers, or JSON in a mockup conflict with the shared schema/core, keep the visual treatment and bind it to real repository-supported behavior instead.
 
-Loaded Vibes itself is dark-only.
+If a required mockup is absent from the working tree, stop rather than guessing its visual content.
 
-Preferred characteristics:
+## Brand and visual direction
+
+Loaded Vibes is dark-only.
+
+Use the established brand family:
 
 - near-black canvas;
-- restrained bordered panels;
-- electric blue, violet, and magenta accents;
-- luminous but controlled gradients;
-- script treatment limited to the Loaded Vibes wordmark or selected hero emphasis;
-- mono typography for technical labels and commands;
-- clean sans typography for dense product information;
-- compact developer-tool controls;
-- diagrams and code/CLI surfaces that feel operational rather than decorative.
+- white primary type;
+- muted teal/cyan centered on `#2f7a8d` and closely related accessible tones;
+- restrained glow rather than neon saturation;
+- thin bordered dark panels;
+- Big Shoulders-style condensed display treatment for major Loaded Vibes headings where available;
+- clean sans-serif UI/body typography;
+- Loaded Vibes crown/circuit motif as a controlled brand device;
+- Digital Herencia desert/circuit landscape as a lower-page/footer device;
+- Digital Herencia parent-brand lockup kept secondary to Loaded Vibes.
 
-Avoid beige editorial styling, startup-confetti aesthetics, oversized generic SaaS sections, and dashboard-density for its own sake.
+Avoid violet/magenta-heavy styling, beige editorial styling, startup-confetti aesthetics, excessive gradients, partner grids, decorative dashboard density, and marketing sections that do not improve product comprehension.
 
-## Configurator
+Preserve the repository-root `public/` brand assets. Website implementation may import or otherwise consume them through the smallest build-compatible approach, but must not delete that directory or its source images.
 
-The configurator should feel like a project workbench:
+## Product landing page
 
-```text
-┌───────────────────┬──────────────────────────────────────┐
-│ PROJECT           │ resolved project / preview           │
-│ Optional surfaces │                                      │
-│ Integrations      │ fixed foundation                     │
-│ Identity          │ retained routes / integrations       │
-│ Design            │ output summary                       │
-│ Review            │ representative generated-app preview │
-├───────────────────┴──────────────────────────────────────┤
-│ loaded-vibes create ... --config loadedvibes.json        │
-└──────────────────────────────────────────────────────────┘
-```
+The landing page follows `context/mockups/landing.png` and should communicate, with minimal copy:
 
-The web UI must consume the browser-safe shared core rather than implementing its own configuration semantics.
+- Loaded Vibes generates a serious production-minded SaaS starting point;
+- the user chooses bounded product/configuration differences rather than architecture;
+- Builder is the primary interactive CTA;
+- Libraries exposes the product building blocks;
+- Docs is the canonical end-user reference;
+- the output is a real generated repository owned by the user.
 
-## Output
+The hero/product preview may summarize Builder state, but must not expose fake provider choices or unsupported configuration.
 
-The initial web configurator exports:
+## Libraries
 
-- `loadedvibes.json`;
+`/libraries` is a browsable product-building-block catalog, not a package registry.
+
+The mockup groups concepts under a small number of categories such as Foundation, Identity, Data, Revenue, and Interface. Presentation metadata may be web-owned, but configuration truth must come from existing repository sources where available:
+
+- `packages/core/src/capabilities.ts` for capability labels, dependencies, and fixed/configurable status;
+- `packages/core/src/presets.ts` for real product presets;
+- `packages/schema/src/recipe.ts` for valid recipe fields;
+- the fixed-foundation governance for non-configurable architectural elements.
+
+Do not duplicate dependency/fixed semantics in a second web-only rules engine.
+
+Individual library pages should make configuration/status the primary useful content. A configurable capability may show the smallest valid `loadedvibes.json` example needed to enable it. A fixed-foundation library must be identified as fixed/included rather than exposing a decorative toggle or fake provider selector. Related-library links are presentation/navigation metadata only.
+
+## Builder
+
+`/configure` is the Builder.
+
+The Builder follows `context/mockups/builder.png`: a compact configuration panel paired with a readable recipe/result preview. It should feel like composing a supported starting point, not completing a long wizard.
+
+The Builder must preserve the existing stateless capabilities that are still product-valid:
+
+- shared schema/core resolution;
+- real product presets;
+- real configurable modules/capabilities;
+- product identity fields;
+- bounded design fields;
+- copy/download of `loadedvibes.json`;
+- copyable CLI handoff;
+- shareable serialized configuration if it remains cheap and working.
+
+Fixed architecture and fixed capabilities may be shown as read-only selected/included items for comprehension, but never as user-switchable choices.
+
+The configuration/result panel should show actual normalized configuration and resolved inclusions. A representative generated-app preview is optional and should be removed if it no longer serves the mockup-driven Builder experience or duplicates the recipe/result preview.
+
+## Docs
+
+`/docs/*` remains a conventional end-user documentation experience backed by canonical content in `docs/`.
+
+The docs renderer does not need a bespoke mockup-driven content redesign. It should share the global brand/navigation shell where practical without making documentation harder to read or introducing decorative product-page density.
+
+## Output and statelessness
+
+The Builder may provide:
+
+- `loadedvibes.json` copy/download;
 - a copyable CLI command;
-- a readable summary of what the CLI will produce.
+- a shareable local/URL representation when already supported;
+- a readable summary of resolved output.
 
-It does not perform the local generation itself.
+It does not perform local generation on the hosted website.
 
-## Preview
+## Implementation economy
 
-Preview representative generated-product surfaces. Do not show architecture metadata as fake application content.
+For the mockup replacement:
 
-The generated dashboard should look like a dashboard, not like:
-
-```text
-Runtime: RSC
-Writes: Actions
-Authz: Rows
-```
-
-Architecture explanation belongs in docs, context, `loaded-vibes explain`, or generated repository guidance.
+- prefer refactoring/reusing the current app routes, shared config helpers, and browser-safe core;
+- introduce only shared components that remove real duplication across the mocked pages;
+- delete obsolete CSS/components/helpers after their final caller is removed;
+- do not add a UI framework, icon package, animation library, design-token system, or new validation harness merely to reproduce the mockups;
+- use the existing web typecheck/build and only narrowly relevant repository checks.

--- a/context/specs/LV-208-web-shell-landing.md
+++ b/context/specs/LV-208-web-shell-landing.md
@@ -1,0 +1,76 @@
+---
+id: LV-208
+title: Replace the shared web shell and Product landing page
+status: active
+type: implementation-spec
+order: 8
+depends_on: []
+issue_title: 'LV-208: Replace the web shell and Product landing page from mockups'
+---
+
+# LV-208 — Replace the shared web shell and Product landing page
+
+## Outcome
+
+Replace the current generic website chrome and `/` page with the Loaded Vibes / Digital Herencia UI shown in `context/mockups/landing.png`, while establishing only the small shared shell needed by later Libraries and Builder work.
+
+## Required inputs
+
+- `context/mockups/landing.png` must exist in the implementation working tree.
+- `context/docs/web.md`
+- `context/docs/product.md`
+- `.agents/contracts/product.yaml`
+- current `apps/web` implementation
+
+If the mockup is absent, stop instead of approximating it.
+
+## Starting state
+
+The current site uses `SiteHeader` with `Overview`, `Docs`, and `Open configurator`; `/` renders three editorial sections; global styling is concentrated in `apps/web/app/globals.css`.
+
+## Primary files
+
+Expected edits are intentionally narrow:
+
+- `apps/web/app/layout.tsx`
+- `apps/web/app/page.tsx`
+- `apps/web/app/globals.css`
+- `apps/web/components/site-header.tsx`
+
+Add a shared footer/brand component only if it removes real duplication needed by LV-209/LV-210. Reuse existing repository brand assets; do not delete the repository-root `public/` directory or its images.
+
+## Scope
+
+- replace primary navigation with `Product | Libraries | Docs | Builder`;
+- keep `/` as Product and `/configure` as the Builder route;
+- reproduce the landing mockup's Loaded Vibes brand section, product hero, Builder preview treatment, three product-entry cards, three-step flow, category strip, and Digital Herencia footer/landscape hierarchy;
+- make CTA links functional: Builder -> `/configure`, Libraries -> `/libraries`, Docs -> `/docs`;
+- use concise product copy consistent with current product/governance rather than inventing providers or architecture choices;
+- establish reusable shell/footer/brand styling only where LV-209/LV-210 need the same treatment;
+- keep docs content/renderer intact.
+
+## Non-goals
+
+- do not implement Libraries pages in this issue;
+- do not refactor Builder configuration behavior in this issue;
+- do not add animation libraries, icon packages, UI frameworks, or a new design-system layer;
+- do not redesign generator/core/schema/template code;
+- do not add new tests or visual-test infrastructure.
+
+## Acceptance
+
+- `/` visually follows `context/mockups/landing.png` rather than the previous page;
+- shared header and footer match the mockup family and navigation routes correctly;
+- branding uses the existing Loaded Vibes/Digital Herencia assets and black/white/teal direction;
+- no mockup placeholder is turned into unsupported configuration/product behavior;
+- `/docs/*` still renders through the shared shell without a content redesign;
+- obsolete landing-specific markup/styles replaced by this issue are removed rather than retained in parallel.
+
+## Verification
+
+Run only:
+
+1. `pnpm --dir apps/web typecheck`
+2. `pnpm --dir apps/web build`
+
+Use direct visual inspection of `/` at desktop width and one narrow responsive width against the mockup. Do not run repository-wide `pnpm validate` for this presentation-only issue.

--- a/context/specs/LV-208-web-shell-landing.md
+++ b/context/specs/LV-208-web-shell-landing.md
@@ -12,17 +12,27 @@ issue_title: 'LV-208: Replace the web shell and Product landing page from mockup
 
 ## Outcome
 
-Replace the current generic website chrome and `/` page with the Loaded Vibes / Digital Herencia UI shown in `context/mockups/landing.png`, while establishing only the small shared shell needed by later Libraries and Builder work.
+Replace the current generic website chrome and `/` page with the Loaded Vibes / Digital Herencia Product/landing mockup in local `context/mockups/`, while establishing only the small shared shell needed by later Libraries and Builder work.
 
 ## Required inputs
 
-- `context/mockups/landing.png` must exist in the implementation working tree.
-- `context/docs/web.md`
-- `context/docs/product.md`
-- `.agents/contracts/product.yaml`
-- current `apps/web` implementation
+- inspect local `context/mockups/` and identify the Product/landing mockup by visual content;
+- `context/docs/web.md`;
+- `context/docs/product.md`;
+- `.agents/contracts/product.yaml`;
+- current `apps/web` implementation.
 
-If the mockup is absent, stop instead of approximating it.
+If the required mockup subject is absent, stop instead of approximating it.
+
+## Architecture guardrail
+
+Implement the affected surface using the applicable Loaded Vibes / Codependent Coding presentation grammar:
+
+```text
+route/page -> feature/presentation orchestration -> shared presentation
+```
+
+Keep pages thin, prefer Server Components, and add no client boundary unless interaction requires one. Do not create ceremonial layers with no behavior.
 
 ## Starting state
 
@@ -37,14 +47,17 @@ Expected edits are intentionally narrow:
 - `apps/web/app/globals.css`
 - `apps/web/components/site-header.tsx`
 
-Add a shared footer/brand component only if it removes real duplication needed by LV-209/LV-210. Reuse existing repository brand assets; do not delete the repository-root `public/` directory or its images.
+A focused `features/product` or equivalent presentation feature may replace page-level bulk when it keeps `app/page.tsx` thin. Add a shared footer/brand component only if it removes real duplication needed by LV-209/LV-210.
+
+Reuse existing repository brand assets. Do not delete the repository-root `public/` directory or its images.
 
 ## Scope
 
 - replace primary navigation with `Product | Libraries | Docs | Builder`;
 - keep `/` as Product and `/configure` as the Builder route;
-- reproduce the landing mockup's Loaded Vibes brand section, product hero, Builder preview treatment, three product-entry cards, three-step flow, category strip, and Digital Herencia footer/landscape hierarchy;
+- faithfully reproduce the landing mockup's section structure, hierarchy, spacing, proportions, dark surfaces, Builder-preview treatment, product-entry cards, flow/category treatment, and Digital Herencia footer/landscape treatment;
 - make CTA links functional: Builder -> `/configure`, Libraries -> `/libraries`, Docs -> `/docs`;
+- adapt literal button labels/copy when necessary so they describe real Loaded Vibes behavior without changing the depicted interaction purpose;
 - use concise product copy consistent with current product/governance rather than inventing providers or architecture choices;
 - establish reusable shell/footer/brand styling only where LV-209/LV-210 need the same treatment;
 - keep docs content/renderer intact.
@@ -59,9 +72,10 @@ Add a shared footer/brand component only if it removes real duplication needed b
 
 ## Acceptance
 
-- `/` visually follows `context/mockups/landing.png` rather than the previous page;
+- `/` faithfully reproduces the identified Product/landing mockup rather than the previous page or a reinterpretation;
 - shared header and footer match the mockup family and navigation routes correctly;
 - branding uses the existing Loaded Vibes/Digital Herencia assets and black/white/teal direction;
+- literal mockup copy is adjusted only when needed for truthful product behavior;
 - no mockup placeholder is turned into unsupported configuration/product behavior;
 - `/docs/*` still renders through the shared shell without a content redesign;
 - obsolete landing-specific markup/styles replaced by this issue are removed rather than retained in parallel.

--- a/context/specs/LV-209-web-libraries.md
+++ b/context/specs/LV-209-web-libraries.md
@@ -1,0 +1,144 @@
+---
+id: LV-209
+title: Add mockup-driven Libraries catalog and detail pages
+status: active
+type: implementation-spec
+order: 9
+depends_on: [LV-208]
+issue_title: 'LV-209: Add the Libraries catalog and linked detail pages from mockups'
+---
+
+# LV-209 — Add the Libraries catalog and linked detail pages
+
+## Outcome
+
+Add `/libraries` and `/libraries/[slug]` using the local Libraries and individual-library mockups as the visual contract, while making every card/detail page describe the real Loaded Vibes / Hipster Stack system rather than inventing a generic component or provider marketplace.
+
+## Required inputs
+
+Read only:
+
+- this spec;
+- `context/docs/web.md`;
+- `context/docs/configuration.md`;
+- `.agents/contracts/product.yaml`;
+- local `context/mockups/` and identify the Libraries catalog and individual-library/configuration mockups by visual content;
+- `packages/core/src/capabilities.ts`;
+- `packages/core/src/presets.ts` only if needed for Builder handoff/preset wording;
+- `packages/schema/src/recipe.ts`;
+- the directly affected `apps/web` files.
+
+If either required mockup subject is absent, stop rather than approximating its design.
+
+## Architecture guardrail
+
+Follow the applicable Loaded Vibes presentation grammar:
+
+```text
+route/page -> feature/presentation orchestration -> shared/domain presentation
+```
+
+Pages stay thin and server-first. Library metadata may be a small pure web presentation model. It must not become a second configuration engine.
+
+## Starting state
+
+There is currently no `/libraries` route or library detail route. Core already owns capability IDs, labels, dependencies, and fixed/configurable status; schema already owns valid recipe fields.
+
+## Primary files
+
+Expected additions/edits are narrow:
+
+- `apps/web/app/libraries/page.tsx`
+- `apps/web/app/libraries/[slug]/page.tsx`
+- one small presentation catalog, e.g. `apps/web/lib/libraries.ts`
+- one focused Libraries feature/presentation component only if useful to keep route files thin
+- shared card/icon presentation only when actually reused
+- `apps/web/app/globals.css`
+- shared header/footer only for active navigation/layout reuse
+
+Do not modify `packages/core`, `packages/schema`, CLI, generator, or template merely to make the mockups literal.
+
+## Catalog model
+
+Preserve the mockup's five-column conceptual organization and low density:
+
+- **Foundation** — Core, Generator
+- **Identity** — Auth, Organizations
+- **Data** — Database, RBAC
+- **Revenue** — Billing, Subscriptions
+- **Interface** — Blocks, Docs
+
+Interpret those cards through the actual Codependent Coding / Loaded Vibes architecture:
+
+- **Core** — the fixed Loaded Vibes application grammar/foundation, not a package toggle;
+- **Generator** — deterministic one-template generation and CLI handoff;
+- **Auth** — Clerk authentication/session boundary plus application-owned identity adaptation; fixed, not provider-selectable;
+- **Organizations** — application-owned tenant/organization/membership model; currently fixed via core capability semantics;
+- **Database** — Neon/Postgres + Prisma + tenant containment/RLS boundary; fixed, not database-selectable;
+- **RBAC** — local membership/role/capability authorization; currently fixed via core capability semantics;
+- **Billing** — the real optional `billing` capability;
+- **Subscriptions** — the subscription lifecycle supplied by Billing; do not create a second recipe field;
+- **Blocks** — the presentation composition/building-block model; fixed architectural/presentation concept, not a fake module;
+- **Docs** — Loaded Vibes end-user docs/product surface, linking to `/docs` where appropriate.
+
+Presentation metadata may own only slug, category, concise copy, icon/presentation key, related links, and a mapping to an existing capability/product surface.
+
+## Detail-page behavior
+
+Faithfully reproduce the individual-library mockup's structure, spacing, page hierarchy, configuration-first panel, small supporting cards, related-library links, and footer treatment.
+
+Apply intelligent semantics instead of literal mockup mistakes:
+
+- configurable capability pages show the smallest valid `loadedvibes.json` fragment needed to express the choice;
+- fixed foundation pages show **Included / Fixed foundation** status and useful configuration/setup context, not a toggle;
+- Billing uses the real capability identifier and dependency behavior from core;
+- Subscriptions explains that it is delivered through Billing and links/configures Billing rather than inventing `subscriptions: true`;
+- Auth must not implement illustrative keys such as `provider`, `sessions`, or `protectedRoutes` because they are not current recipe fields;
+- Database must not expose Prisma/Neon/provider choice controls;
+- Organizations/RBAC status is derived from `capabilityRegistry`, not duplicated constants;
+- Generator uses an actual CLI/config handoff;
+- Docs routes to the canonical docs surface;
+- Builder actions route to `/configure` and may pre-seed only configuration that the existing serialization path can truthfully represent with a small change.
+
+Button labels/copy may differ from the mockup when needed to make the real action obvious; preserve the button's location, hierarchy, and interaction purpose.
+
+## Scope
+
+- implement all catalog cards and detail routes;
+- keep content concise and product-oriented rather than turning each page into documentation;
+- wire all related-library links;
+- wire honest Builder/Docs/CLI handoffs;
+- preserve LV-208 shared shell/brand treatment;
+- use existing core/schema semantics instead of replicating them;
+- remove temporary/duplicate metadata or styling before completion.
+
+## Non-goals
+
+- no package registry;
+- no provider marketplace;
+- no arbitrary technology selector;
+- no new schema fields merely to satisfy mockup placeholder text;
+- no docs-content rewrite;
+- no search/index backend;
+- no new testing or screenshot infrastructure.
+
+## Acceptance
+
+- `/libraries` faithfully reproduces the identified catalog mockup's layout, density, hierarchy, card treatment, branding, and responsive intent;
+- all ten cards lead to useful routes or the canonical destination without dead links;
+- individual detail pages faithfully reproduce the identified detail mockup's composition while using truthful Loaded Vibes semantics;
+- fixed architecture is visibly fixed/read-only, not selectable;
+- configurable examples use only actual schema/core identifiers;
+- Billing/Subscriptions do not become duplicate configuration concepts;
+- no second capability dependency/fixed-status rules engine exists in `apps/web`;
+- route files remain thin and presentation remains free of provider/DB authority;
+- no unrelated repository surfaces change.
+
+## Verification
+
+Run only:
+
+1. `pnpm --dir apps/web typecheck`
+2. `pnpm --dir apps/web build`
+
+Then inspect `/libraries`, one fixed detail page (`Auth`), and the real configurable detail (`Billing`) at desktop width against the mockups. Check one narrow responsive width for overflow/navigation only. Do not run repository-wide `pnpm validate`.

--- a/context/specs/LV-210-web-builder-refresh.md
+++ b/context/specs/LV-210-web-builder-refresh.md
@@ -1,0 +1,169 @@
+---
+id: LV-210
+title: Refactor the Builder to match the mockup and real configuration model
+status: active
+type: implementation-spec
+order: 10
+depends_on: [LV-208, LV-209]
+issue_title: 'LV-210: Refactor Builder UI/UX to match the mockup and real config semantics'
+---
+
+# LV-210 — Refactor Builder UI/UX to match the mockup and real config semantics
+
+## Outcome
+
+Replace the current multi-section configurator UI with the compact Builder composition shown in the local Builder mockup, while preserving the real stateless Loaded Vibes configuration contract, CLI/JSON handoff, and Codependent Coding / Hipster Stack boundaries.
+
+## Required inputs
+
+Read only:
+
+- this spec;
+- `context/docs/web.md`;
+- `context/docs/configuration.md`;
+- `.agents/contracts/product.yaml`;
+- local `context/mockups/` and identify the Builder mockup by visual content;
+- `apps/web/components/configurator.tsx`;
+- `apps/web/lib/configurator.ts`;
+- `packages/core/src/capabilities.ts`;
+- `packages/core/src/presets.ts`;
+- `packages/schema/src/recipe.ts`;
+- directly imported preview/style files only when deciding whether they remain necessary.
+
+Do not crawl `template/`, DevNotes, CodependentCoding, or unrelated generator code unless a concrete semantic contradiction appears.
+
+## Architecture guardrail
+
+Keep the current Builder as a deliberate client island over browser-safe core semantics:
+
+```text
+/configure route -> Builder client feature -> pure controls/result presentation
+                                  |
+                                  -> @loaded-vibes/core/browser
+```
+
+Do not move product authority into UI components. Do not introduce server state, protected I/O, provider SDK calls, Prisma, or unnecessary Server Actions.
+
+## Starting state
+
+The current `Configurator` already supports:
+
+- stateless draft state;
+- URL recipe deserialization/share link;
+- real optional capabilities;
+- product identity fields;
+- bounded design choices;
+- normalized recipe resolution;
+- JSON download;
+- CLI command copy;
+- representative generated-app preview.
+
+Its information architecture and styling no longer match the Builder mockup. The existing `LivePreview`/preview metadata may be redundant once the mockup's normalized recipe/result panel becomes the primary preview.
+
+## Primary files
+
+Expected edits are intentionally concentrated:
+
+- `apps/web/components/configurator.tsx`
+- `apps/web/lib/configurator.ts` only where small helpers/default handling improve the new composition
+- `apps/web/app/globals.css`
+- `apps/web/app/configure/page.tsx` only if route-level presentation needs a small adjustment
+- `apps/web/components/live-preview.tsx` and `apps/web/lib/preview.ts` only to remove them if no longer used
+- LV-208 shared shell/header/footer only for active navigation consistency
+
+Do not rename files/components merely for cosmetic vocabulary if keeping them saves edits and causes no ambiguity.
+
+## Builder composition
+
+Faithfully reproduce the mockup's overall structure:
+
+- concise `Builder` heading and one-line explanation;
+- compact top actions;
+- left configuration card organized into a small number of horizontal groups;
+- right `Recipe Preview` / selected-stack area;
+- readable normalized `loadedvibes.json` panel with copy action;
+- compact output/handoff summary beneath;
+- shared Digital Herencia landscape/footer treatment.
+
+The exact labels/options must reflect real Loaded Vibes semantics rather than the illustrative mockup.
+
+### Recommended real control mapping
+
+Use the smallest layout that preserves all current useful configuration:
+
+1. **Starting point / preset** — map to actual `productPresets`: Bare golden app, B2B SaaS, Client portal, Platform/marketplace.
+2. **Product identity** — compact package name, display name, and description controls.
+3. **Optional product surfaces** — real configurable capabilities such as Invitations, Onboarding, Admin, Marketing, Sample Domain.
+4. **Revenue** — real Billing and Stripe Connect controls with existing dependency resolution.
+5. **Design** — compact controls for the existing theme/mode/radius/density/navigation fields.
+
+Do not copy fake mockup choices such as `SaaS | Dashboard | Internal Tool` if they do not map cleanly to current presets. Preserve the visual selector treatment while using the real presets.
+
+Fixed foundation concepts such as Auth/Clerk, Organizations, RBAC, Neon/Postgres, Prisma, RLS, and core governance may appear in the mockup-style **Selected Stack** summary as read-only included items. They must not become toggles or provider selectors.
+
+## Actions and output
+
+Preserve real existing behavior using labels appropriate to the mockup hierarchy:
+
+- copy/download normalized `loadedvibes.json`;
+- copy CLI command;
+- share recipe URL if it remains working and cheap;
+- reflect dependency auto-inclusion truthfully;
+- show actual included/excluded optional capabilities in a compact way.
+
+Do not label a hosted website action `Generate Stack` if it does not actually generate locally/hosted. Use a truthful action such as `Download Recipe`, `Copy CLI Command`, or equivalent while preserving the primary-action placement shown in the mockup.
+
+## Refactor and cleanup
+
+- reuse `resolveConfiguratorRecipe`, serialization, dependency resolution, and shared core rather than rewriting them;
+- simplify state/rendering around the new groups rather than maintaining old and new layouts simultaneously;
+- if `LivePreview` and `lib/preview.ts` have no remaining product value/callers after the result-panel redesign, delete them in this issue;
+- remove obsolete old workbench CSS/classes after their final use;
+- dedupe shared card/button/layout styles created by LV-208/LV-209 when a small consolidation is obvious;
+- do not perform a broad CSS architecture rewrite just because the stylesheet is large;
+- do not add dependencies unless the mockup is impossible to reproduce with existing React/CSS/assets, and assume it is not impossible until proven otherwise.
+
+## Docs integration
+
+No docs-page mockup is required. Confirm only that `/docs/*` remains readable and uses the shared global shell/navigation. Do not redesign documentation content or build a new documentation framework.
+
+## Non-goals
+
+- no hosted generation;
+- no account/backend state;
+- no arbitrary provider/stack choices;
+- no new recipe schema unless a genuine pre-existing product requirement is discovered and separately escalated;
+- no template/generator refactor;
+- no new tests, Playwright suite, visual-regression system, analytics, observability, or design-system project.
+
+## Acceptance
+
+- `/configure` faithfully reproduces the identified Builder mockup's composition, spacing, visual hierarchy, panel geometry, dark/teal treatment, and responsive intent;
+- every interactive control maps to an actual current preset, recipe field, or configurable capability;
+- fixed foundation items are read-only summaries, never decorative toggles;
+- the displayed JSON is the actual normalized configuration consumed by the CLI/core;
+- copy/download/CLI/share behavior that remains visible works;
+- dependency resolution remains delegated to shared core;
+- old workbench UI and dead preview code/styles are removed after replacement;
+- `/`, `/libraries`, representative library detail, `/configure`, and `/docs` share one coherent shell/brand family;
+- implementation remains a stateless client feature over browser-safe core, consistent with Loaded Vibes architecture;
+- no unrelated template/core/CLI behavior changes.
+
+## Verification
+
+Use only the checks required to establish the changed web surface:
+
+1. `pnpm --dir apps/web typecheck`
+2. `pnpm --dir apps/web build`
+
+Then manually exercise at least:
+
+- switch between two real presets;
+- toggle Billing and Stripe Connect and confirm resolved dependencies/output change correctly;
+- change product identity and one design field;
+- copy/download recipe and copy CLI command;
+- load one share URL if share remains exposed;
+- inspect Builder at desktop width against the mockup and one narrow width for overflow/usability;
+- smoke `/`, `/libraries`, one library detail, and `/docs` for shell/navigation regressions.
+
+Do not run repository-wide `pnpm validate` unless one of these focused checks exposes a cross-package regression that requires it.

--- a/context/specs/README.md
+++ b/context/specs/README.md
@@ -1,39 +1,40 @@
 # Loaded Vibes Implementation Specs
 
-These specs record the completed issue-sized roadmap for the one-template repository migration.
+GitHub Issues are the operational queue. Each active implementation Issue corresponds to one focused spec. The spec is durable scope and acceptance context, not a second project-management system.
 
-GitHub Issues are the operational queue. Each Issue should correspond to one spec. The spec is durable scope and acceptance context, not a second project-management system.
-
-## Completed order
+## Completed one-template migration
 
 1. **LV-201** — consolidate the one repository-owned master template.
 2. **LV-202** — simplify configuration and absorb recipe ownership.
 3. **LV-203** — convert generation to one-template retain/remove ownership.
-4. **LV-204** — split and polish the developer-tool landing page and configurator.
+4. **LV-204** — split the developer-tool landing page and configurator.
 5. **LV-205** — add canonical end-user docs and `/docs`.
 6. **LV-206** — polish the CLI/package around the final model.
 7. **LV-207** — remove migration debris and prepare the coherent release.
 
-## Dependency map
+## Active mockup-driven web refresh
+
+The current web UI/UX replacement is deliberately only three implementation units:
+
+1. **LV-208** — replace the shared shell and Product landing page from the local mockup.
+2. **LV-209** — add the Libraries catalog and linked detail pages from the local mockups.
+3. **LV-210** — refactor the Builder around the local mockup, preserve real config semantics, and remove replaced web code.
 
 ```text
-LV-201 template ownership
-     │
-     ├──────────────┐
-     ▼              ▼
-LV-202 config     template source ready
-     │
-     ▼
-LV-203 generator
-     │
-     ├──────────────┬──────────────┐
-     ▼              ▼              ▼
-LV-204 web      LV-205 docs     LV-206 CLI/package
-     └──────────────┴──────────────┘
-                    │
-                    ▼
-               LV-207 cleanup
+LV-208 shell + Product
+          │
+          ▼
+LV-209 Libraries + detail
+          │
+          ▼
+LV-210 Builder + final web cleanup
 ```
+
+This sequence is intentionally small. Do not split it further unless an actual blocked dependency makes one Issue unreviewable.
+
+## Visual authority
+
+For LV-208 through LV-210, the local `context/mockups/` subjects are the visual acceptance artifacts. `context/docs/web.md` defines how to interpret them: reproduce design/structure faithfully, but adapt literal labels and controls when needed to implement truthful Loaded Vibes behavior.
 
 ## Historical specs
 
@@ -41,6 +42,6 @@ LV-101 through LV-110 are preserved in Git history and are not active instructio
 
 ## Verification rule
 
-The user explicitly does not want new tests or validation systems as part of this cleanup.
+Do not create new test or validation systems for this UI replacement.
 
-Use existing checks only when they directly establish the behavior changed by the active Issue.
+Use existing web typecheck/build plus the narrow manual interaction/visual checks named by the active spec. Escalate to wider repository checks only when focused verification exposes a real cross-package regression.

--- a/llms.txt
+++ b/llms.txt
@@ -2,20 +2,29 @@
 
 > Loaded Vibes is an opinionated developer tool and deterministic generator that turns a bounded project configuration into a complete white-label Hipster Stack application from one repository-owned maximal template.
 
-Use `context/docs/*.md` for active product and architecture source-of-truth contracts, `docs/` for canonical end-user guidance, and `AGENTS.md` for repository authority and agent workflow. The live repository is organized around `packages/schema` for the shared configuration contract, `packages/core` for deterministic resolution and generation, `packages/cli` for terminal UX, `apps/web` for the stateless website/configurator, and `template/` as the sole executable application source.
+Use `AGENTS.md` for authority and minimal reading order. Use the matching active `context/specs/LV-*.md` as the implementation unit, `context/docs/*.md` for durable product/architecture contracts, and `docs/` for canonical end-user guidance. The live repository is organized around `packages/schema` for the shared configuration contract, `packages/core` for deterministic resolution and generation, `packages/cli` for terminal UX, `apps/web` for Product/Libraries/Builder/Docs, and `template/` as the sole executable application source.
 
-The CLI, web configurator, and `loadedvibes.json` share one configuration model. Generated projects preserve the repository's fixed Hipster Stack foundation; configuration is limited to choices the template and generator can honor deterministically.
+The CLI, web Builder, and `loadedvibes.json` share one configuration model. Generated projects preserve the fixed Hipster Stack / Loaded Vibes WebApp Architecture; configuration is limited to choices the template and generator can honor deterministically.
+
+## Active Work
+
+- [Specification Index](context/specs/README.md): Current implementation order and verification rules.
+- [LV-208 Product Shell and Landing](context/specs/LV-208-web-shell-landing.md): Replace shared web chrome and `/` from the local Product mockup.
+- [LV-209 Libraries](context/specs/LV-209-web-libraries.md): Add `/libraries` and linked detail pages from the local Libraries mockups using real Loaded Vibes semantics.
+- [LV-210 Builder Refresh](context/specs/LV-210-web-builder-refresh.md): Replace Builder UI/UX from the local mockup while preserving the shared configuration contract and removing replaced web code.
+- [Web Surface Contract](context/docs/web.md): Mockup authority, truthful-semantic rule, brand direction, Loaded Vibes presentation architecture, Libraries model, Builder behavior, and token-conscious implementation constraints.
+
+For LV-208 through LV-210, inspect only the relevant local `context/mockups/` visual subject, the named spec/docs/contracts, the affected `apps/web` files, and directly imported core/schema semantics. Do not re-inventory the template or entire knowledge repositories without a concrete contradiction.
 
 ## Documentation
 
-- [Repository README](README.md): Primary project overview, CLI usage, configurator behavior, generated output, provider handoff, and repository development commands.
-- [Context Index](context/README.md): Maintainer context map and guidance for locating product, architecture, specification, and governance material.
+- [Repository README](README.md): Primary project overview, CLI usage, Builder behavior, generated output, provider handoff, and repository development commands.
+- [Context Index](context/README.md): Maintainer context map and active-work guidance.
 - [Product Definition](context/docs/product.md): Authoritative product purpose, user, value, surfaces, fixed foundation, configurable scope, non-goals, and system relationships.
 - [Repository and Generator Architecture](context/docs/architecture.md): Authoritative repository topology, package boundaries, one-template generation model, application grammar, provenance, and safety rules.
 - [Configuration Model](context/docs/configuration.md): Authoritative shared configuration semantics, supported choice categories, presets, and configuration-honesty rules.
 - [Generator and CLI Contract](context/docs/generator-cli.md): Maintainer contract for generation behavior and the CLI execution surface.
 - [Master Template Contract](context/docs/template.md): Maintainer contract for the repository-owned maximal application template and its ownership boundaries.
-- [Web Surface Contract](context/docs/web.md): Maintainer contract for the developer website, visual configurator, previews, and stateless behavior.
 - [Documentation Contract](context/docs/documentation.md): Maintainer contract for canonical end-user documentation and website documentation rendering.
 
 ## End-User Guides
@@ -36,56 +45,34 @@ The CLI, web configurator, and `loadedvibes.json` share one configuration model.
 - [Optional Surfaces](docs/configuration/optional-surfaces.md): Supported optional application surfaces and dependency behavior.
 - [Design Configuration](docs/configuration/design.md): Supported semantic visual-direction configuration.
 
-## Specifications
+## Completed Migration Specs
 
-- [Specification Index](context/specs/README.md): Completed issue-sized roadmap, dependency order, and verification rule for the one-template repository migration.
-- [LV-201 Master Template Consolidation](context/specs/LV-201-consolidate-master-template.md): Scope and acceptance context for consolidating one repository-owned master template.
-- [LV-202 Configuration Core Simplification](context/specs/LV-202-simplify-configuration-core.md): Scope and acceptance context for simplifying configuration and ownership semantics.
-- [LV-203 One-Template Generator](context/specs/LV-203-one-template-generator.md): Scope and acceptance context for deterministic retain/remove generation from one template.
-- [LV-204 Web Landing and Configurator](context/specs/LV-204-web-landing-configurator.md): Scope and acceptance context for the website and visual configurator.
-- [LV-205 End-User Documentation](context/specs/LV-205-end-user-docs.md): Scope and acceptance context for canonical user documentation and `/docs`.
-- [LV-206 CLI and Package Polish](context/specs/LV-206-cli-package-polish.md): Scope and acceptance context for the final CLI and package model.
-- [LV-207 Cleanup and Release](context/specs/LV-207-cleanup-release.md): Scope and acceptance context for migration cleanup and release coherence.
+- [LV-201 Master Template Consolidation](context/specs/LV-201-consolidate-master-template.md)
+- [LV-202 Configuration Core Simplification](context/specs/LV-202-simplify-configuration-core.md)
+- [LV-203 One-Template Generator](context/specs/LV-203-one-template-generator.md)
+- [LV-204 Web Landing and Configurator](context/specs/LV-204-web-landing-configurator.md)
+- [LV-205 End-User Documentation](context/specs/LV-205-end-user-docs.md)
+- [LV-206 CLI and Package Polish](context/specs/LV-206-cli-package-polish.md)
+- [LV-207 Cleanup and Release](context/specs/LV-207-cleanup-release.md)
 
 ## Core Implementation
 
 - [Shared Configuration Schema](packages/schema/src/recipe.ts): Zod-backed public configuration shapes and enums shared by CLI, core, and web surfaces.
 - [Core Public API](packages/core/src/index.ts): Main exports for the deterministic generator core.
 - [Capability Catalog](packages/core/src/capabilities.ts): Supported configurable capabilities and their relationships.
+- [Product Presets](packages/core/src/presets.ts): Real one-template starting-point defaults used by CLI/web.
 - [Template Ownership Model](packages/core/src/ownership.ts): Ownership metadata used to retain or remove generator-owned template material.
-- [Generated Manifest](packages/core/src/manifest.ts): Provenance representation for generated projects.
-- [CLI Entry Point](packages/cli/src/cli.ts): Command parsing and terminal execution surface.
-- [Create Flow](packages/cli/src/create-flow.ts): Interactive and configuration-driven project creation flow.
-- [Web Package](apps/web/package.json): Dependencies and scripts for the stateless website and configurator application.
-
-## Master Template
-
-- [Template README](template/README.md): Architecture, stack, route map, RBAC model, provider boundaries, validation, and operating guidance for the generated application foundation.
-- [Template Metadata](template/.loaded-vibes-template.json): Repository-owned metadata identifying the canonical master template.
-- [Template Environment Example](template/.env.example): Provider and application environment variables expected by generated projects.
-- [Template Agent Guidance](template/AGENTS.md): Source precedence and working constraints inherited by the master application source.
-
-## Repository Configuration
-
-- [Root Package Manifest](package.json): Published package identity, binaries, scripts, toolchain requirements, dependencies, and packaged files.
-- [pnpm Workspace](pnpm-workspace.yaml): Monorepo workspace boundaries.
-- [TypeScript Configuration](tsconfig.json): Repository TypeScript compiler settings and workspace source coverage.
-- [Package Build Configuration](tsdown.config.ts): Build configuration for the published CLI package.
-- [Web Deployment Configuration](vercel.json): Vercel build and deployment settings for the repository web surface.
-- [Test Configuration](vitest.config.ts): Vitest configuration for repository unit, integration, and generated-project tests.
+- [Web Package](apps/web/package.json): Dependencies and scripts for the stateless website.
 
 ## Governance
 
-- [Repository Agent Governance](AGENTS.md): Authority hierarchy, task-specific reading order, product model, fixed foundation, repository target, working rules, and delivery process.
-- [Context Agent Guidance](context/AGENTS.md): Scoped instructions for modifying maintainer product, architecture, and specification context.
-- [Product Machine Contract](.agents/contracts/product.yaml): Compact machine-readable product boundaries derived from controlling documentation.
+- [Repository Agent Governance](AGENTS.md): Authority hierarchy, task-specific minimal reading order, fixed foundation, working rules, and delivery process.
+- [Product Machine Contract](.agents/contracts/product.yaml): Compact machine-readable product/web boundaries.
 - [Architecture Machine Contract](.agents/contracts/architecture.yaml): Compact machine-readable repository and generator architecture boundaries.
-- [Transition Machine Contract](.agents/contracts/transition.yaml): Compact machine-readable migration and repository-transition boundaries.
-- [Security Policy](SECURITY.md): Repository security expectations and vulnerability-reporting guidance.
-- [Contributing Guide](CONTRIBUTING.md): Contributor workflow and repository contribution expectations.
+- [Transition Machine Contract](.agents/contracts/transition.yaml): Compact machine-readable historical migration boundaries.
 
 ## Optional
 
-- [Repository Transition](context/docs/repository-transition.md): Historical transition rules and constraints for moving from migration-era topology to the current one-template repository shape.
-- [Release Contract](context/docs/release.md): Maintainer release and cleanup guidance.
+- [Repository Transition](context/docs/repository-transition.md): Historical transition rules for the completed one-template migration.
+- [Release Contract](context/docs/release.md): Maintainer release guidance.
 - [Troubleshooting](docs/troubleshooting.md): End-user fixes for common local generation and provider-readiness problems.


### PR DESCRIPTION
## Summary

Refresh repository governance for the approved Loaded Vibes website replacement before Codex implementation begins.

- makes the local mockups the visual acceptance standard while keeping shared schema/core authoritative for behavior;
- anchors implementation to the Codependent Coding / Hipster Stack / Loaded Vibes WebApp Architecture proportionally;
- adds Product, Libraries, Builder, and Docs as the coherent web surface;
- adds the three-issue LV-208 → LV-210 implementation roadmap;
- constrains Codex reading, edits, and verification to reduce token use;
- preserves the repository-root `public/` brand assets.

No runtime/product code changes are included.
