### PR TITLE
feat(web): add libraries catalog and details

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -89,6 +89,25 @@ button {
   box-shadow: 0 0 8px #57c7df;
   content: '';
 }
+body:has(.libraries-page, .library-detail-page)
+  .site-header
+  nav
+  a:first-child::after {
+  display: none;
+}
+body:has(.libraries-page, .library-detail-page)
+  .site-header
+  nav
+  a:nth-child(2)::after {
+  position: absolute;
+  right: 0;
+  bottom: -12px;
+  left: 0;
+  height: 1px;
+  background: var(--acid);
+  box-shadow: 0 0 8px #57c7df;
+  content: '';
+}
 .site-header .nav-cta {
   padding: 9px 16px;
   border: 1px solid #35616d;
@@ -464,12 +483,14 @@ button {
 .heritage-landscape {
   overflow: hidden;
   max-width: 1536px;
+  height: clamp(260px, 24vw, 340px);
   margin: auto;
 }
 .heritage-landscape > img {
   display: block;
   width: 100%;
-  height: auto;
+  height: 100%;
+  object-fit: cover;
 }
 .footer-bar {
   display: grid;
@@ -501,6 +522,292 @@ button {
   justify-self: end;
   color: #536166;
   font-size: 8px;
+}
+.libraries-page,
+.library-detail-page {
+  width: min(1480px, calc(100% - 64px));
+  margin: auto;
+}
+.libraries-page {
+  padding: 58px 0 48px;
+}
+.libraries-heading h1,
+.library-detail-heading h1 {
+  margin: 0;
+  font-size: clamp(58px, 7vw, 96px);
+  font-weight: 650;
+  letter-spacing: -0.055em;
+  line-height: 0.95;
+}
+.libraries-heading > p,
+.library-detail-heading > span {
+  display: block;
+  max-width: 720px;
+  margin: 24px 0 0;
+  color: #9cabad;
+  font-size: 17px;
+  line-height: 1.55;
+}
+.library-columns {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 24px;
+  margin-top: 48px;
+}
+.library-category h2 {
+  margin: 0 6px 14px;
+  color: var(--acid);
+  font-size: 15px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+.library-category > div {
+  display: grid;
+  gap: 7px;
+}
+.library-category a {
+  display: grid;
+  grid-template-columns: 58px 1fr;
+  gap: 14px;
+  align-items: center;
+  min-height: 128px;
+  padding: 18px;
+  border: 1px solid #294049;
+  border-radius: 11px;
+  background: linear-gradient(145deg, #07131a, #03080d);
+  color: var(--ink);
+  text-decoration: none;
+}
+.library-category a:hover {
+  border-color: #53a9ba;
+  box-shadow: 0 0 28px #2f7a8d22;
+}
+.library-category svg,
+.library-detail-page svg {
+  width: 52px;
+  height: 52px;
+  fill: none;
+  stroke: #8ee8ee;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.35;
+  filter: drop-shadow(0 0 5px #53ccd466);
+}
+.library-category strong {
+  display: block;
+  margin-bottom: 8px;
+  font-size: 16px;
+  font-weight: 600;
+}
+.library-category small {
+  display: block;
+  color: #8b9a9d;
+  font-size: 12px;
+  line-height: 1.5;
+}
+.library-detail-page {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 390px;
+  gap: 28px;
+  min-height: 760px;
+  padding: 44px 0 86px;
+}
+.library-detail-heading > p {
+  display: inline-flex;
+  margin: 0 0 18px;
+  padding: 7px 17px;
+  border: 1px solid #2ab8ac;
+  border-radius: 99px;
+  color: #4bd7ce;
+  font-size: 11px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+.library-detail-heading > span {
+  max-width: 820px;
+  margin-top: 12px;
+}
+.library-detail-actions {
+  display: flex;
+  gap: 14px;
+  margin-top: 22px;
+}
+.library-detail-actions .button {
+  min-width: 168px;
+}
+.configuration-panel {
+  overflow: hidden;
+  margin-top: 24px;
+  padding: 18px;
+  border: 1px solid #294049;
+  border-radius: 8px;
+  background: linear-gradient(145deg, #07131a, #03080d);
+}
+.configuration-panel-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 0 4px 14px;
+  color: #d3dede;
+  font:
+    700 11px/1 ui-monospace,
+    monospace;
+}
+.configuration-panel-heading span b {
+  color: #4bd7ce;
+  font-weight: inherit;
+}
+.configuration-panel-heading > strong {
+  color: #7fa1a7;
+  font-size: 9px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.configuration-panel pre {
+  min-height: 208px;
+  margin: 0;
+  padding: 22px;
+  border: 1px solid #1b3037;
+  border-radius: 7px;
+  background: #03090e;
+  color: #5fe3d6;
+  font:
+    15px/1.65 ui-monospace,
+    monospace;
+  white-space: pre-wrap;
+}
+.fixed-status {
+  display: grid;
+  grid-template-columns: 74px minmax(0, 1fr);
+  gap: 20px;
+  align-items: center;
+  min-height: 208px;
+  padding: 26px;
+  border: 1px solid #1b3037;
+  border-radius: 7px;
+  background:
+    radial-gradient(circle at 10% 50%, #2d899633, transparent 12rem), #03090e;
+}
+.fixed-status svg {
+  width: 68px;
+  height: 68px;
+}
+.fixed-status strong {
+  display: block;
+  margin-bottom: 10px;
+  font-size: 21px;
+}
+.fixed-status small {
+  display: block;
+  max-width: 620px;
+  color: #8b9a9d;
+  font-size: 13px;
+  line-height: 1.6;
+}
+.library-highlights {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+  margin-top: 16px;
+}
+.library-highlights article {
+  display: grid;
+  grid-template-columns: 40px 1fr;
+  gap: 12px;
+  align-items: center;
+  min-height: 106px;
+  padding: 15px;
+  border: 1px solid #294049;
+  border-radius: 7px;
+  background: #061017;
+}
+.library-highlights article > span {
+  display: grid;
+  width: 34px;
+  height: 34px;
+  place-items: center;
+  border: 1px solid #2a817f;
+  border-radius: 50%;
+  color: #6ee2dc;
+  font:
+    700 9px/1 ui-monospace,
+    monospace;
+}
+.library-highlights strong {
+  display: block;
+  margin-bottom: 6px;
+  font-size: 13px;
+}
+.library-highlights small {
+  display: block;
+  color: #89989b;
+  font-size: 10px;
+  line-height: 1.5;
+}
+.library-detail-sidebar {
+  display: grid;
+  align-content: start;
+  gap: 16px;
+  padding-top: 190px;
+}
+.related-panel {
+  padding: 16px;
+  border: 1px solid #294049;
+  border-radius: 8px;
+  background: linear-gradient(145deg, #07131a, #03080d);
+}
+.related-panel h2 {
+  margin: 0 0 12px;
+  font-size: 18px;
+}
+.related-panel > div {
+  display: grid;
+  gap: 7px;
+}
+.related-panel a {
+  display: grid;
+  grid-template-columns: 38px 1fr auto;
+  gap: 12px;
+  align-items: center;
+  min-height: 58px;
+  padding: 8px;
+  border: 1px solid #273d45;
+  border-radius: 6px;
+  color: var(--ink);
+  text-decoration: none;
+}
+.related-panel a:hover {
+  border-color: #50a6b5;
+}
+.related-panel svg {
+  width: 34px;
+  height: 34px;
+  padding: 5px;
+  border: 1px solid #348e90;
+  border-radius: 5px;
+}
+.related-panel strong,
+.related-panel small {
+  display: block;
+}
+.related-panel strong {
+  margin-bottom: 3px;
+  font-size: 13px;
+}
+.related-panel small {
+  overflow: hidden;
+  color: #839296;
+  font-size: 10px;
+  line-height: 1.3;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.related-panel a > b {
+  color: #d9e5e5;
+  font-size: 24px;
+  font-weight: 300;
 }
 .docs-shell {
   display: grid;
@@ -1420,6 +1727,20 @@ details p {
   .footer-bar {
     padding: 0 20px;
   }
+  .libraries-page,
+  .library-detail-page {
+    width: min(100% - 40px, 720px);
+  }
+  .library-columns {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .library-detail-page {
+    grid-template-columns: 1fr;
+  }
+  .library-detail-sidebar {
+    grid-template-columns: 1fr 1fr;
+    padding-top: 0;
+  }
   .workspace {
     grid-template-columns: 1fr;
   }
@@ -1528,6 +1849,32 @@ details p {
   }
   .footer-bar nav {
     display: none;
+  }
+  .libraries-page {
+    padding-top: 38px;
+  }
+  .libraries-heading h1,
+  .library-detail-heading h1 {
+    font-size: 58px;
+  }
+  .libraries-heading > p,
+  .library-detail-heading > span {
+    font-size: 14px;
+  }
+  .library-columns,
+  .library-highlights,
+  .library-detail-sidebar {
+    grid-template-columns: 1fr;
+  }
+  .library-category a {
+    min-height: 106px;
+  }
+  .library-detail-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+  .fixed-status {
+    grid-template-columns: 1fr;
   }
   .step {
     padding: 22px;

--- a/apps/web/app/libraries/[slug]/page.tsx
+++ b/apps/web/app/libraries/[slug]/page.tsx
@@ -1,0 +1,19 @@
+import { notFound } from 'next/navigation';
+import { LibraryDetail } from '@/features/libraries/library-detail';
+import { getLibrary, libraries } from '@/lib/libraries';
+
+export function generateStaticParams() {
+  return libraries.map((library) => ({ slug: library.slug }));
+}
+
+export default async function LibraryPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const library = getLibrary(slug);
+  if (!library) notFound();
+
+  return <LibraryDetail library={library} />;
+}

--- a/apps/web/app/libraries/page.tsx
+++ b/apps/web/app/libraries/page.tsx
@@ -1,0 +1,5 @@
+import { LibrariesCatalog } from '@/features/libraries/libraries-catalog';
+
+export default function LibrariesPage() {
+  return <LibrariesCatalog />;
+}

--- a/apps/web/components/library-icon.tsx
+++ b/apps/web/components/library-icon.tsx
@@ -1,0 +1,74 @@
+import type { LibraryIcon as LibraryIconName } from '@/lib/libraries';
+
+export function LibraryIcon({ name }: { name: LibraryIconName }) {
+  const paths: Record<LibraryIconName, React.ReactNode> = {
+    core: (
+      <>
+        <path d="m12 3 9 5-9 5-9-5 9-5Z" />
+        <path d="m3 12 9 5 9-5M3 16l9 5 9-5" />
+      </>
+    ),
+    generator: (
+      <>
+        <circle cx="12" cy="12" r="2" />
+        <path d="M12 2v6M12 16v6M2 12h6M16 12h6M5 5l4 4M15 15l4 4M19 5l-4 4M9 15l-4 4" />
+      </>
+    ),
+    auth: (
+      <>
+        <rect x="5" y="10" width="14" height="11" rx="1" />
+        <path d="M8 10V7a4 4 0 0 1 8 0v3M12 14v3" />
+      </>
+    ),
+    organizations: (
+      <>
+        <circle cx="9" cy="8" r="4" />
+        <circle cx="16.5" cy="9" r="3.5" />
+        <path d="M2.5 21a6.5 6.5 0 0 1 13 0M13 16.5A6 6 0 0 1 21.5 21" />
+      </>
+    ),
+    database: (
+      <>
+        <ellipse cx="12" cy="5" rx="8" ry="3" />
+        <path d="M4 5v6c0 1.7 3.6 3 8 3s8-1.3 8-3V5M4 11v6c0 1.7 3.6 3 8 3s8-1.3 8-3v-6" />
+      </>
+    ),
+    rbac: (
+      <>
+        <path d="M12 2 4 6v6c0 5 3.4 8.4 8 10 4.6-1.6 8-5 8-10V6l-8-4Z" />
+        <circle cx="12" cy="10" r="2.5" />
+        <path d="M8.5 17a3.5 3.5 0 0 1 7 0" />
+      </>
+    ),
+    billing: (
+      <>
+        <rect x="3" y="5" width="18" height="14" rx="1" />
+        <path d="M3 10h18M7 15h4" />
+      </>
+    ),
+    subscriptions: (
+      <>
+        <path d="M18 7h4V3M6 17H2v4" />
+        <path d="M20 10a8 8 0 0 0-14-5L2 9M4 14a8 8 0 0 0 14 5l4-4" />
+        <path d="M14.5 9c-.5-.7-1.3-1-2.5-1-1.4 0-2.5.7-2.5 1.8 0 2.4 5 1 5 3.4 0 1.1-1.1 1.8-2.5 1.8-1.2 0-2.1-.4-2.6-1.2M12 6.5v10" />
+      </>
+    ),
+    blocks: (
+      <>
+        <path d="m12 2 5 3-5 3-5-3 5-3ZM7 9l5 3 5-3M7 13l5 3 5-3M3 8l4 2.5v5L3 13V8ZM17 10.5 21 8v5l-4 2.5v-5Z" />
+      </>
+    ),
+    docs: (
+      <>
+        <path d="M4 5.5A3.5 3.5 0 0 1 7.5 2H12v18H7.5A3.5 3.5 0 0 0 4 23.5v-18Z" />
+        <path d="M20 5.5A3.5 3.5 0 0 0 16.5 2H12v18h4.5a3.5 3.5 0 0 1 3.5 3.5v-18Z" />
+      </>
+    ),
+  };
+
+  return (
+    <svg aria-hidden="true" viewBox="0 0 24 24">
+      {paths[name]}
+    </svg>
+  );
+}

--- a/apps/web/features/libraries/libraries-catalog.tsx
+++ b/apps/web/features/libraries/libraries-catalog.tsx
@@ -1,0 +1,34 @@
+import Link from 'next/link';
+import { LibraryIcon } from '@/components/library-icon';
+import { libraries, libraryCategories } from '@/lib/libraries';
+
+export function LibrariesCatalog() {
+  return (
+    <main className="libraries-page">
+      <header className="libraries-heading">
+        <h1>Libraries</h1>
+        <p>Composable product building blocks for the Loaded Vibes system.</p>
+      </header>
+      <section className="library-columns" aria-label="Loaded Vibes libraries">
+        {libraryCategories.map((category) => (
+          <div className="library-category" key={category}>
+            <h2>{category}</h2>
+            <div>
+              {libraries
+                .filter((library) => library.category === category)
+                .map((library) => (
+                  <Link href={`/libraries/${library.slug}`} key={library.slug}>
+                    <LibraryIcon name={library.icon} />
+                    <span>
+                      <strong>{library.title}</strong>
+                      <small>{library.description}</small>
+                    </span>
+                  </Link>
+                ))}
+            </div>
+          </div>
+        ))}
+      </section>
+    </main>
+  );
+}

--- a/apps/web/features/libraries/library-detail.tsx
+++ b/apps/web/features/libraries/library-detail.tsx
@@ -1,0 +1,105 @@
+import Link from 'next/link';
+import { LibraryIcon } from '@/components/library-icon';
+import {
+  getRelatedLibraries,
+  getWorksWithLibraries,
+  type LibraryItem,
+} from '@/lib/libraries';
+
+function RelatedList({
+  title,
+  libraries,
+}: {
+  title: string;
+  libraries: LibraryItem[];
+}) {
+  return (
+    <section className="related-panel">
+      <h2>{title}</h2>
+      <div>
+        {libraries.map((library) => (
+          <Link href={`/libraries/${library.slug}`} key={library.slug}>
+            <LibraryIcon name={library.icon} />
+            <span>
+              <strong>{library.title}</strong>
+              <small>{library.description}</small>
+            </span>
+            <b>›</b>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function LibraryDetail({ library }: { library: LibraryItem }) {
+  const related = getRelatedLibraries(library);
+  const worksWith = getWorksWithLibraries(library);
+  const isFixed = library.status === 'Fixed foundation';
+
+  return (
+    <main className="library-detail-page">
+      <div className="library-detail-main">
+        <header className="library-detail-heading">
+          <p>{library.category}</p>
+          <h1>{library.title}</h1>
+          <span>{library.summary}</span>
+          <div className="library-detail-actions">
+            <Link className="button primary" href={library.primaryAction.href}>
+              {library.primaryAction.label} <b>→</b>
+            </Link>
+            <Link className="button" href="/docs">
+              Read the Docs <b>→</b>
+            </Link>
+          </div>
+        </header>
+
+        <section className="configuration-panel">
+          <div className="configuration-panel-heading">
+            <span>
+              {library.example ? 'USE IN' : 'STATUS IN'} <b>loadedvibes.json</b>
+            </span>
+            <strong>{library.status}</strong>
+          </div>
+          {library.example ? (
+            <pre>{library.example}</pre>
+          ) : (
+            <div className="fixed-status">
+              <LibraryIcon name={library.icon} />
+              <span>
+                <strong>
+                  {isFixed ? 'Included / Fixed foundation' : 'Product surface'}
+                </strong>
+                <small>
+                  {isFixed
+                    ? 'No provider selector or decorative toggle. Loaded Vibes owns this supported foundation.'
+                    : 'Use the canonical Loaded Vibes destination for this product surface.'}
+                </small>
+              </span>
+            </div>
+          )}
+        </section>
+
+        <section
+          className="library-highlights"
+          aria-label={`${library.title} highlights`}
+        >
+          {library.highlights.map((highlight, index) => (
+            <article key={highlight.title}>
+              <span>{String(index + 1).padStart(2, '0')}</span>
+              <div>
+                <strong>{highlight.title}</strong>
+                <small>{highlight.description}</small>
+              </div>
+            </article>
+          ))}
+        </section>
+      </div>
+
+      <aside className="library-detail-sidebar">
+        <RelatedList title="Related Libraries" libraries={related} />
+        <RelatedList title="Works With" libraries={worksWith} />
+      </aside>
+    </main>
+  );
+}

--- a/apps/web/lib/libraries.ts
+++ b/apps/web/lib/libraries.ts
@@ -1,0 +1,367 @@
+import {
+  capabilityRegistry,
+  type CapabilityId,
+} from '@loaded-vibes/core/browser';
+
+export const libraryCategories = [
+  'Foundation',
+  'Identity',
+  'Data',
+  'Revenue',
+  'Interface',
+] as const;
+
+export type LibraryCategory = (typeof libraryCategories)[number];
+export type LibraryIcon =
+  | 'core'
+  | 'generator'
+  | 'auth'
+  | 'organizations'
+  | 'database'
+  | 'rbac'
+  | 'billing'
+  | 'subscriptions'
+  | 'blocks'
+  | 'docs';
+
+interface LibraryCopy {
+  slug: string;
+  title: string;
+  category: LibraryCategory;
+  description: string;
+  summary: string;
+  icon: LibraryIcon;
+  capability?: CapabilityId;
+  configurationCapability?: CapabilityId;
+  primaryAction: { label: string; href: string };
+  example?: string;
+  highlights: readonly { title: string; description: string }[];
+  related: readonly string[];
+  worksWith: readonly string[];
+}
+
+export interface LibraryItem extends LibraryCopy {
+  status: 'Configurable capability' | 'Fixed foundation' | 'Product surface';
+}
+
+const libraryCopy: readonly LibraryCopy[] = [
+  {
+    slug: 'core',
+    title: 'Core',
+    category: 'Foundation',
+    description: 'Application grammar and production-minded primitives.',
+    summary:
+      'The fixed Hipster Stack foundation: server-first routes, feature orchestration, validation, authorization, and transactional boundaries.',
+    icon: 'core',
+    primaryAction: {
+      label: 'Read the architecture',
+      href: '/docs/concepts/one-template',
+    },
+    highlights: [
+      {
+        title: 'Server first',
+        description: 'React Server Components and thin App Router routes.',
+      },
+      {
+        title: 'Owned boundaries',
+        description: 'Features, actions, workflows, selects, and adapters.',
+      },
+      {
+        title: 'Production defaults',
+        description: 'A coherent baseline rather than stack shopping.',
+      },
+    ],
+    related: ['generator', 'blocks', 'database'],
+    worksWith: ['docs', 'generator'],
+  },
+  {
+    slug: 'generator',
+    title: 'Generator',
+    category: 'Foundation',
+    description: 'Deterministic one-template project generation.',
+    summary:
+      'The Loaded Vibes CLI resolves one portable recipe, retains supported surfaces, applies structured transforms, and creates a user-owned repository.',
+    icon: 'generator',
+    primaryAction: { label: 'Open the Builder', href: '/configure' },
+    example: 'pnpm dlx create-loaded-vibes@latest --config loadedvibes.json',
+    highlights: [
+      {
+        title: 'One template',
+        description: 'A single repository-owned maximal application source.',
+      },
+      {
+        title: 'Portable recipe',
+        description: 'The CLI and Builder share loadedvibes.json semantics.',
+      },
+      {
+        title: 'Deterministic output',
+        description: 'Retain, remove, transform, install, and git setup.',
+      },
+    ],
+    related: ['core', 'blocks', 'docs'],
+    worksWith: ['billing', 'organizations'],
+  },
+  {
+    slug: 'auth',
+    title: 'Auth',
+    category: 'Identity',
+    description: 'Clerk identity and session boundary.',
+    summary:
+      'Clerk supplies identity and sessions while the generated application owns user adaptation, tenant membership, roles, and capabilities.',
+    icon: 'auth',
+    primaryAction: { label: 'Included in every build', href: '/configure' },
+    highlights: [
+      {
+        title: 'Clerk boundary',
+        description: 'Identity and session verification are fixed foundation.',
+      },
+      {
+        title: 'App-owned users',
+        description: 'Provider identity is adapted into local product records.',
+      },
+      {
+        title: 'Protected operations',
+        description: 'Authorization remains an application decision.',
+      },
+    ],
+    related: ['rbac', 'organizations', 'database'],
+    worksWith: ['core', 'generator'],
+  },
+  {
+    slug: 'organizations',
+    title: 'Organizations',
+    category: 'Identity',
+    description: 'Application-owned tenants and memberships.',
+    summary:
+      'Organizations, memberships, and tenant context are part of the generated application rather than delegated to a hosted organization product.',
+    icon: 'organizations',
+    capability: 'organizations',
+    primaryAction: { label: 'Included in every build', href: '/configure' },
+    highlights: [
+      {
+        title: 'Local ownership',
+        description: 'Organizations and membership data live in the app.',
+      },
+      {
+        title: 'Tenant context',
+        description: 'Requests resolve an explicit active organization.',
+      },
+      {
+        title: 'Required foundation',
+        description: 'Core marks Organizations as fixed.',
+      },
+    ],
+    related: ['auth', 'rbac', 'database'],
+    worksWith: ['billing', 'subscriptions'],
+  },
+  {
+    slug: 'database',
+    title: 'Database',
+    category: 'Data',
+    description: 'Neon/Postgres, Prisma, and tenant containment.',
+    summary:
+      'The data foundation combines Postgres persistence, Prisma access, application authorization, and RLS where the template uses it for containment.',
+    icon: 'database',
+    primaryAction: {
+      label: 'Review generated setup',
+      href: '/docs/generated-project/provider-setup',
+    },
+    highlights: [
+      {
+        title: 'Postgres',
+        description:
+          'Neon-oriented relational persistence is fixed foundation.',
+      },
+      {
+        title: 'Prisma',
+        description: 'Typed access and migrations follow one supported path.',
+      },
+      {
+        title: 'Tenant containment',
+        description: 'Authorization and RLS protect organization data.',
+      },
+    ],
+    related: ['organizations', 'rbac', 'core'],
+    worksWith: ['billing', 'auth'],
+  },
+  {
+    slug: 'rbac',
+    title: 'RBAC',
+    category: 'Data',
+    description: 'Local roles, capabilities, and authorization.',
+    summary:
+      'Membership roles and capabilities are enforced by the generated application and composed with tenant context at protected boundaries.',
+    icon: 'rbac',
+    capability: 'rbac',
+    primaryAction: { label: 'Included in every build', href: '/configure' },
+    highlights: [
+      {
+        title: 'Local policy',
+        description: 'Roles and capabilities remain application-owned.',
+      },
+      {
+        title: 'Default deny',
+        description: 'Protected operations require explicit authorization.',
+      },
+      {
+        title: 'Organization scope',
+        description: 'RBAC depends on the fixed Organizations capability.',
+      },
+    ],
+    related: ['auth', 'organizations', 'database'],
+    worksWith: ['admin', 'billing'],
+  },
+  {
+    slug: 'billing',
+    title: 'Billing',
+    category: 'Revenue',
+    description: 'Optional subscription billing capability.',
+    summary:
+      'Billing is a real configurable capability. Enabling it includes Organizations through core-owned dependency resolution and retains the supported billing surface.',
+    icon: 'billing',
+    capability: 'billing',
+    configurationCapability: 'billing',
+    primaryAction: { label: 'Configure Billing', href: '/configure' },
+    example: `{
+  "modules": {
+    "billing": true
+  }
+}`,
+    highlights: [
+      {
+        title: 'Real capability',
+        description: 'billing is a valid loadedvibes.json module field.',
+      },
+      {
+        title: 'Dependency aware',
+        description: 'Organizations is resolved automatically.',
+      },
+      {
+        title: 'Provider handoff',
+        description: 'Generated projects still require owner setup.',
+      },
+    ],
+    related: ['subscriptions', 'organizations', 'database'],
+    worksWith: ['generator', 'docs'],
+  },
+  {
+    slug: 'subscriptions',
+    title: 'Subscriptions',
+    category: 'Revenue',
+    description: 'Lifecycle supplied by the Billing capability.',
+    summary:
+      'Plans, recurring access, usage, and subscription lifecycle belong to Billing. Subscriptions are not a second configuration switch.',
+    icon: 'subscriptions',
+    configurationCapability: 'billing',
+    primaryAction: { label: 'Configure Billing', href: '/configure' },
+    example: `{
+  "modules": {
+    "billing": true
+  }
+}`,
+    highlights: [
+      {
+        title: 'One model',
+        description: 'No duplicate subscriptions recipe field.',
+      },
+      {
+        title: 'Billing lifecycle',
+        description: 'Recurring product access is delivered through Billing.',
+      },
+      {
+        title: 'Shared dependencies',
+        description: 'The core resolver includes Organizations.',
+      },
+    ],
+    related: ['billing', 'organizations', 'rbac'],
+    worksWith: ['generator', 'docs'],
+  },
+  {
+    slug: 'blocks',
+    title: 'Blocks',
+    category: 'Interface',
+    description: 'Composable presentation primitives and sections.',
+    summary:
+      'shadcn-compatible primitives and composed presentation follow the route → feature → presentation layering of the Loaded Vibes architecture.',
+    icon: 'blocks',
+    primaryAction: { label: 'Explore the Builder', href: '/configure' },
+    highlights: [
+      {
+        title: 'Composable UI',
+        description: 'Primitives stay separate from product authority.',
+      },
+      {
+        title: 'Server-first',
+        description: 'Client islands exist only where interaction needs them.',
+      },
+      {
+        title: 'Product ready',
+        description:
+          'Generated surfaces are a starting point, not placeholders.',
+      },
+    ],
+    related: ['core', 'generator', 'docs'],
+    worksWith: ['auth', 'billing'],
+  },
+  {
+    slug: 'docs',
+    title: 'Docs',
+    category: 'Interface',
+    description: 'Canonical Loaded Vibes end-user guidance.',
+    summary:
+      'The repository-owned docs explain configuration, CLI operation, generated-project handoff, and provider setup without inventing product behavior.',
+    icon: 'docs',
+    primaryAction: { label: 'Open the Docs', href: '/docs' },
+    highlights: [
+      {
+        title: 'Canonical source',
+        description: 'One docs tree serves repository and website readers.',
+      },
+      {
+        title: 'Truthful handoff',
+        description: 'Generated output and owner setup stay distinct.',
+      },
+      {
+        title: 'Developer focused',
+        description: 'Concise guidance for building after generation.',
+      },
+    ],
+    related: ['generator', 'core', 'blocks'],
+    worksWith: ['billing', 'auth'],
+  },
+] as const;
+
+function libraryStatus(item: LibraryCopy): LibraryItem['status'] {
+  const capability = item.capability ?? item.configurationCapability;
+  if (capability) {
+    return capabilityRegistry[capability].fixed
+      ? 'Fixed foundation'
+      : 'Configurable capability';
+  }
+  return ['core', 'auth', 'database', 'blocks'].includes(item.slug)
+    ? 'Fixed foundation'
+    : 'Product surface';
+}
+
+export const libraries: readonly LibraryItem[] = libraryCopy.map((item) => ({
+  ...item,
+  status: libraryStatus(item),
+}));
+
+export function getLibrary(slug: string): LibraryItem | undefined {
+  return libraries.find((item) => item.slug === slug);
+}
+
+export function getRelatedLibraries(item: LibraryItem): LibraryItem[] {
+  return item.related.flatMap((slug) => {
+    const related = getLibrary(slug);
+    return related ? [related] : [];
+  });
+}
+
+export function getWorksWithLibraries(item: LibraryItem): LibraryItem[] {
+  return item.worksWith.flatMap((slug) => {
+    const related = getLibrary(slug);
+    return related ? [related] : [];
+  });
+}


### PR DESCRIPTION
## Summary
- add the mockup-driven Libraries catalog and all linked library detail pages
- describe the real Loaded Vibes / Hipster Stack foundation without creating a provider or package marketplace
- keep routes server-first and configuration authority in shared core/schema

## Changes
- add ten library cards across Foundation, Identity, Data, Revenue, and Interface
- add statically generated detail routes with configuration/status panels, highlights, and related links
- derive Organizations/RBAC fixed status and Billing configurability from capabilityRegistry
- represent Subscriptions through the real billing capability and use only the valid modules.billing recipe field

## QA
- pnpm --dir apps/web typecheck
- pnpm --dir apps/web build
- browser inspection of /libraries, /libraries/auth, and /libraries/billing at 1440x900
- narrow inspection at 390x844; verified no horizontal overflow
- clicked Auth from the catalog; verified fixed status, Billing JSON, links, and clean browser logs

## Risks / Notes
- no core, schema, CLI, generator, template, docs content, dependencies, or testing infrastructure changed

Closes #130