### PR TITLE
governance: define Hipster Stack web overhaul

### DIFF
--- a/.agents/contracts/architecture.yaml
+++ b/.agents/contracts/architecture.yaml
@@ -25,17 +25,35 @@ shared_configuration:
 
 boundaries:
   web:
-    owns: [product-presentation, interactive-docs-presentation, builder-local-orchestration]
-    forbidden: [filesystem-generation, provider-secrets, duplicate-configuration-authority]
+    owns:
+      - product-presentation
+      - interactive-docs-presentation
+      - builder-local-orchestration
+    forbidden:
+      - filesystem-generation
+      - provider-secrets
+      - duplicate-configuration-authority
   cli:
     owns: [command-parsing, prompts, terminal-output, core-invocation]
     forbidden: [second-configuration-resolver]
   generator:
-    owns: [normalization, composition-resolution, generator-template-catalog, generation-plan, materialization, transforms, provenance]
+    owns:
+      - normalization
+      - composition-resolution
+      - generator-template-catalog
+      - generation-plan
+      - materialization
+      - transforms
+      - provenance
     forbidden: [nextjs-web-presentation, template-runtime-product-ui]
   template:
     standalone_application: true
-    forbidden: [generator-ownership-catalog, pruning-instructions, builder-state, cli-implementation, generation-plan]
+    forbidden:
+      - generator-ownership-catalog
+      - pruning-instructions
+      - builder-state
+      - cli-implementation
+      - generation-plan
 
 generated_application:
   preserve_codependent_coding_grammar: true

--- a/.agents/contracts/architecture.yaml
+++ b/.agents/contracts/architecture.yaml
@@ -1,72 +1,53 @@
-schema_version: 3
-id: loaded-vibes.architecture
+schema_version: 4
+id: hipster-stack.architecture
 authority: machine-contract
 sources:
   - context/docs/architecture.md
   - context/docs/template.md
   - context/docs/configuration.md
   - context/docs/generator-cli.md
+  - context/docs/web.md
 
-repository_target:
-  apps:
-    - web
-  packages:
-    - cli
-    - core
-    - schema
+current_repository:
+  apps: [web]
+  packages: [cli, core, schema]
   template_path: template
-  end_user_docs_path: docs
+  docs_path: docs
   maintainer_context_path: context
   machine_governance_path: .agents
 
 shared_configuration:
-  consumers:
-    - cli
-    - web-configurator
-    - loadedvibes-json
+  consumers: [cli, web-builder, portable-config]
   one_schema: true
-  one_normalization_path: true
-  presets_are_optional_defaults: true
-  presets_are_templates: false
-  separate_recipes_package_target: false
-
-core:
-  owns:
-    - configuration-normalization
-    - dependency-resolution
-    - template-ownership-catalog
-    - generation-plan
-    - retain-remove-materialization
-    - structured-transforms
-    - provenance
-    - shared-explanation
-  must_not_depend_on:
-    - terminal-ui
-    - nextjs-web-ui
-
-template:
-  maximal: true
-  white_label: true
-  source_count: 1
-  external_acquisition: false
-  doctrine_authority: DigitalHerencia/DevNotes
-  preserve_hipster_stack_grammar: true
-
-generation:
-  model: copy-one-template-then-retain-remove-and-transform
-  duplicate_module_source_tolerated_as_target: false
+  one_resolution_path: true
+  ui_may_duplicate_dependency_rules: false
   selectable_option_requires_real_generation_effect: true
-  collect_provider_secrets: false
-  network_template_fetch: false
-  windows_first_class: true
-  overwrite_unrelated_nonempty_target: false
 
-web:
-  stateless: true
-  uses_shared_browser_safe_core: true
+boundaries:
+  web:
+    owns: [product-presentation, interactive-docs-presentation, builder-local-orchestration]
+    forbidden: [filesystem-generation, provider-secrets, duplicate-configuration-authority]
+  cli:
+    owns: [command-parsing, prompts, terminal-output, core-invocation]
+    forbidden: [second-configuration-resolver]
+  generator:
+    owns: [normalization, composition-resolution, generator-template-catalog, generation-plan, materialization, transforms, provenance]
+    forbidden: [nextjs-web-presentation, template-runtime-product-ui]
+  template:
+    standalone_application: true
+    forbidden: [generator-ownership-catalog, pruning-instructions, builder-state, cli-implementation, generation-plan]
 
 generated_application:
-  generator_internal_ui: false
-  preserve_application_layer_boundaries: true
-  preserve_auth_authz_boundaries: true
-  preserve_provider_adapter_boundaries: true
+  preserve_codependent_coding_grammar: true
+  routes_adapt: true
+  features_orchestrate: true
+  components_render: true
+  schemas_validate: true
+  generator_internals_leak: false
+
+generation:
+  source_template_count: 1
+  network_template_fetch: false
+  collect_provider_secrets: false
+  windows_first_class: true
+  overwrite_unrelated_nonempty_target: false

--- a/.agents/contracts/product.yaml
+++ b/.agents/contracts/product.yaml
@@ -1,5 +1,5 @@
-schema_version: 4
-id: loaded-vibes.product
+schema_version: 5
+id: hipster-stack.product
 authority: machine-contract
 sources:
   - context/docs/product.md
@@ -7,73 +7,65 @@ sources:
   - context/docs/documentation.md
 
 product:
-  name: Loaded Vibes
+  name: Hipster Stack
   class: opinionated-project-initializer
-  framing: developer-software-factory
+  framing: deterministic-application-composition
   primary_value: repetitive-work-removed-by-generated-project
 
+ecosystem:
+  engineering_knowledge: Codependent Coding
+  generator: Hipster Stack
+  downstream_adaptive_development: Loaded Vibes
+
 authorities:
-  executable_template: DigitalHerencia/LoadedVibes
+  executable_template: this-repository
   engineering_doctrine: DigitalHerencia/DevNotes
-  downstream_adaptive_development: Codependent Coding
+  configuration_semantics: shared-schema-and-generator
 
 surfaces:
-  - master-template
+  - maximal-template
   - shared-configuration
-  - generator-core
+  - generation-engine
   - cli
   - web-product
-  - web-libraries
+  - interactive-docs
   - web-builder
-  - end-user-docs
-  - loadedvibes-json
+  - portable-config
   - generated-application
-
-cli:
-  primary_execution_surface: true
-  canonical_command: loaded-vibes
 
 web:
   stateless: true
   requires_auth: false
   requires_database: false
   hosted_generation_required: false
-  visual_acceptance: mockup-driven
   routes:
     product: /
-    libraries: /libraries
-    library_detail: /libraries/[slug]
-    builder: /configure
     docs: /docs
-  navigation:
-    - Product
-    - Libraries
-    - Docs
-    - Builder
-  semantics:
-    mockups_control_presentation: true
-    shared_core_controls_configuration: true
-    fixed_foundation_is_read_only: true
+    builder: /configure
+    legacy_libraries: redirect-to-docs
+  navigation: [Product, Docs, Builder]
+  mockups_control_presentation: true
+  shared_configuration_controls_semantics: true
+  boldkit_source_is_locally_owned: true
+  tanstack_is_interaction_reference_only: true
 
 template:
   count: 1
   repository_owned: true
-  external_application_source: false
+  standalone_application: true
+  generator_internal_metadata_allowed: false
 
 configuration:
-  fixed_architecture_is_selectable: false
+  one_contract_for_cli_web_file: true
   visible_options_must_change_real_output: true
-  shared_between_cli_web_and_json: true
+  future_options_hidden_until_generator_support: true
+  fixed_method_not_equal_fixed_provider: true
 
 prohibited_product_drift:
   - generic-framework-generator
-  - arbitrary-stack-selector
-  - multiple-application-template-forks
-  - provider-marketplace
-  - plugin-marketplace
+  - provider-or-plugin-marketplace
   - hosted-project-control-plane
   - configurator-account-system
-  - enterprise-governance-product
-  - validation-as-product
-  - automatic-provider-secret-collection
+  - duplicate-web-configuration-engine
+  - generator-machinery-inside-template
   - arbitrary-generated-repository-upgrade-engine

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,20 +1,63 @@
-# Loaded Vibes Governance Directory
+# Hipster Stack Governance Directory
 
-Loaded Vibes is a developer-focused software factory: one repository-owned maximal white-label Hipster Stack template, one deterministic generation engine, one shared configuration contract, a CLI execution surface, a stateless visual Builder, browsable product Libraries, and end-user documentation.
+Hipster Stack™ is the opinionated project initializer implemented in this repository: one repository-owned maximal white-label application, one deterministic composition/generation engine, one shared configuration contract, a CLI execution surface, a stateless visual Builder, and interactive end-user documentation.
 
-This file is the governance directory. Read only the material relevant to the work in front of you.
+This file is the governance directory. Read only the material relevant to the active Issue.
 
 ## Authority
 
-1. The GitHub Issue defines the current unit of work.
-2. `context/specs/LV-*.md` defines the durable implementation scope for that Issue.
-3. `context/docs/*.md` defines the human-readable product and architecture contract.
-4. `.agents/contracts/*.yaml` encodes compact machine-readable boundaries derived from the controlling docs.
-5. The implementation and live repository state establish what currently exists.
-6. DevNotes is the canonical authority for Hipster Stack engineering doctrine.
-7. `.agents/execution/*.json` records decisions, progress, and handoff state. Execution state never overrides the sources above.
+1. The current GitHub Issue defines the unit of work.
+2. The matching `context/specs/HS-*.md` defines durable implementation scope for new work. Historical `LV-*` specs remain provenance, not current direction unless an Issue explicitly names one.
+3. `context/docs/*.md` defines human-readable product and architecture contracts.
+4. `.agents/contracts/*.yaml` encodes compact deterministic boundaries derived from the controlling docs.
+5. The live repository establishes current implementation state.
+6. The Codependent Coding™ Knowledge System in DevNotes is the canonical reusable engineering authority.
+7. `.agents/execution/*.json` records operational state and never overrides canon.
 
-When two sources conflict, do not invent a compromise. Prefer the higher authority and update stale lower-level governance as part of the same focused change when required.
+When sources conflict, do not invent a compromise. Prefer the higher authority and update stale lower-level governance as part of the focused change when required.
+
+## Ecosystem boundary
+
+```text
+Codependent Coding Knowledge System
+  reusable engineering doctrine
+        │
+        ▼
+Hipster Stack
+  deterministic application composition
+        │
+        ▼
+standalone generated application
+        │
+        ▼
+Loaded Vibes
+  adaptive specification-driven development
+        │
+        ▼
+product-specific MVP
+```
+
+Hipster Stack owns deterministic generation and the executable template. Codependent Coding owns reusable knowledge. Loaded Vibes is downstream adaptive tooling and is not a generation/runtime dependency.
+
+## Engineering grammar
+
+The generated application and this repository follow the applicable subset of the canonical method:
+
+> Routes adapt. Features orchestrate. Components render. Fetchers read. Actions write. Schemas validate. Authorization decides. Transactions preserve invariants. Webhooks reconcile external truth.
+
+Apply the grammar proportionally. Static website presentation does not need ceremonial fetchers/actions/workflows.
+
+## Fixed method, configurable composition
+
+The opinionated foundation is the engineering method, responsibility boundaries, trust model, and supported architecture. Concrete providers, modules, capabilities, route surfaces, or policies become editable only when the shared schema and generator can produce the corresponding repository correctly.
+
+Never expose a decorative option that only changes metadata. Current implementation constraints remain real until an implementation Issue changes them.
+
+## Template boundary
+
+`template/` is the standalone maximal white-label application. It must make sense if extracted from this monorepo.
+
+Generator-specific ownership catalogs, pruning rules, Builder state, CLI implementation, and generation instructions belong outside `template/`. Application-local context, tests, CI, and agent contracts may remain when they govern the standalone application itself.
 
 ## Read by task
 
@@ -24,196 +67,37 @@ Read:
 
 1. this file;
 2. `context/README.md`;
-3. the matching `context/specs/LV-*.md`;
-4. only the `context/docs/*` files named by that spec;
-5. only the `.agents/contracts/*` files named by that spec;
-6. the actual files being changed.
+3. the matching active spec;
+4. only docs/contracts named by that spec;
+5. only actual files being changed and direct imports needed to satisfy acceptance.
 
-Do not inventory the entire repository again once the active spec identifies the relevant surface. Expand context only when an actual import, contract, failing check, or acceptance criterion requires it.
-
-### Master template work
-
-Read:
-
-- `context/docs/template.md`
-- `context/docs/architecture.md`
-- `context/docs/repository-transition.md`
-- `.agents/contracts/architecture.yaml`
-- `.agents/contracts/transition.yaml`
-- the relevant Hipster Stack references in DevNotes
-
-### Generator or configuration work
-
-Read:
-
-- `context/docs/configuration.md`
-- `context/docs/generator-cli.md`
-- `context/docs/architecture.md`
-- `.agents/contracts/product.yaml`
-- `.agents/contracts/architecture.yaml`
+Do not inventory the whole repository once the spec identifies the surface.
 
 ### Website work
 
-Read:
+Read the active web spec first, then `context/docs/web.md`, the named mockup(s), and only affected `apps/web` files plus directly required shared configuration code. The mockups control presentation; repository-supported behavior controls semantics.
 
-- the matching web spec first;
-- `context/docs/web.md`;
-- `context/docs/product.md` only when the spec names it;
-- `context/docs/configuration.md` only when changing Builder semantics;
-- `.agents/contracts/product.yaml`;
-- the local `context/mockups/` subject named by the spec;
-- only the affected `apps/web` files plus directly imported core/schema files needed to verify semantics.
+### Generator/configuration work
 
-`context/docs/web.md` already reconciles the applicable Codependent Coding / Loaded Vibes presentation and layer rules for this website. Do not repeatedly crawl CodependentCoding, DevNotes, `template/`, or unrelated generator internals during each visual Issue unless a concrete contradiction or missing semantic requires it.
+Read `context/docs/configuration.md`, `context/docs/generator-cli.md`, `context/docs/architecture.md`, `.agents/contracts/product.yaml`, and `.agents/contracts/architecture.yaml`.
 
-### End-user documentation work
+### Template work
 
-Read:
+Read `context/docs/template.md`, `context/docs/architecture.md`, the relevant machine contract, and only the required Codependent Coding/Hipster Stack references from DevNotes.
 
-- `context/docs/documentation.md`
-- `context/docs/product.md`
-- the relevant docs spec
+## Web-overhaul rules
 
-### Release and cleanup work
-
-Read:
-
-- `context/docs/repository-transition.md`
-- `context/docs/release.md`
-- `.agents/contracts/transition.yaml`
-
-## Product model
-
-```text
-DevNotes
-Hipster Stack doctrine
-        │
-        ▼
-Loaded Vibes
-repository-owned maximal template
-        │
-        ├──────────────┐
-        │              │
-        ▼              ▼
-shared config      website Builder
-schema/core             │
-        │               │
-        ├──────┬────────┘
-        │      │
-        ▼      ▼
-       CLI  loadedvibes.json
-        │      │
-        └──┬───┘
-           ▼
-deterministic retain/remove + transforms
-           │
-           ▼
-generated white-label application
-           │
-           ▼
-Codependent Coding may take product-specific work further
-```
-
-Loaded Vibes does not depend on the Vibes repository. Loaded Vibes owns the executable template. DevNotes owns the engineering doctrine. Codependent Coding is downstream and is not a runtime or generation dependency.
-
-## Fixed foundation
-
-Do not ask users to choose architecture that Loaded Vibes has already decided.
-
-The fixed foundation includes the supported repository-local implementation of:
-
-- TypeScript;
-- Next.js App Router;
-- React Server Components by default;
-- pnpm;
-- Zod;
-- Prisma;
-- Neon/PostgreSQL;
-- Clerk identity/session boundaries;
-- application-owned users, organizations, memberships, roles/capabilities, and tenant authorization;
-- RLS where the template uses it for tenant containment;
-- Fetchers;
-- Server Actions;
-- Workflows;
-- Transactions;
-- Selects and DTO mappers;
-- Integration Adapters;
-- Webhook processors;
-- shadcn-compatible presentation primitives;
-- the Hipster Stack route → feature → presentation layering;
-- the auth/authz and server-operation boundaries;
-- Vercel-oriented deployment assumptions.
-
-## Configurable surface
-
-Expose a choice only when Loaded Vibes can produce the corresponding output correctly.
-
-Useful configuration may include:
-
-- project identity and destination;
-- product identity;
-- optional integrations;
-- optional route groups or route surfaces;
-- optional reusable product capabilities;
-- bounded visual direction;
-- install and git-init behavior;
-- other configuration explicitly backed by template ownership and generator behavior.
-
-Do not create decorative toggles that only change recipe metadata.
-
-## Repository target
-
-```text
-LoadedVibes/
-├── apps/
-│   └── web/
-├── packages/
-│   ├── cli/
-│   ├── core/
-│   └── schema/
-├── template/
-├── docs/
-├── context/
-│   ├── docs/
-│   └── specs/
-├── .agents/
-│   ├── contracts/
-│   └── execution/
-├── scripts/
-├── .github/
-└── AGENTS.md
-```
-
-`packages/recipes`, `templates/golden`, and `templates/modules` were migration-era structures and must not be reintroduced.
-
-## Working rules
-
-- Work one GitHub Issue/spec at a time.
-- Make the smallest complete change that reaches the Issue outcome.
-- Treat current mockups as visual acceptance artifacts where the active web spec says so; reproduce their design faithfully while adapting literal labels/content only when required for truthful product behavior.
-- Preserve working code unless the Issue explicitly requires changing its ownership or location.
-- Delete replaced UI/CSS/helpers after their last caller is gone; do not leave parallel old/new implementations.
-- Do not redesign the Hipster Stack doctrine inside this repo.
-- Do not invent modules, providers, routes, or architecture that the repository does not support.
-- Do not create a generic framework generator, provider marketplace, hosted control plane, or enterprise governance product.
-- Do not create new tests or validation systems unless a future Issue explicitly asks for them.
-- Use existing checks only when they directly establish behavior changed by the current Issue.
-- Never claim a check ran if it did not.
-- Never collect, print, copy, or commit provider secrets.
-- Keep Windows/PowerShell first-class.
-- Keep the web Builder stateless unless a future product decision explicitly changes that.
-- Keep the CLI and web Builder as adapters over the same core configuration semantics.
-- Do not reintroduce `DigitalHerencia/Vibes` as an upstream, source, sync target, reference dependency, or provenance dependency.
+- Current mockups in `context/mockups/` are visual acceptance artifacts.
+- Reproduce their structure, hierarchy, density, spacing, and Hipster Stack/Digital Herencia aesthetic faithfully; adapt literal labels only when needed for truthful behavior.
+- Primary navigation target is `Product | Docs | Builder`; the old Libraries surface folds into interactive Docs with minimal compatibility redirects.
+- Use actual locally owned BoldKit source for UI primitives and selected blocks; BoldKit is an implementation source, not visual authority.
+- TanStack may inform compact interaction hierarchy, inspectable configuration, and generated-plan ergonomics only. Do not copy its visual design or introduce unrelated TanStack technology.
+- Keep the Builder stateless and over the same shared configuration semantics as CLI/config file.
+- Delete replaced UI/CSS/helpers after their final caller is gone.
+- Do not add a backend, CMS, hosted generator, analytics project, visual-regression harness, or broad design-system abstraction merely to reproduce the mockups.
 
 ## Delivery
 
-For implementation work:
+Work one Issue/spec at a time on a short-lived Issue branch. Make the smallest complete change, run only focused existing checks named by the spec, open an Issue-linked PR, delete replaced code, and report executed/skipped/blocked validation truthfully. Merge only when actual acceptance and required CI are satisfied.
 
-1. create or use the GitHub Issue corresponding to the active spec;
-2. implement the Issue on a focused branch;
-3. use proportional existing verification;
-4. open a focused PR linked to the Issue;
-5. update durable governance only if the product or architecture contract changed;
-6. merge when the Issue's actual acceptance criteria are satisfied.
-
-Governance exists to help ship Loaded Vibes. It is not the product.
+Governance exists to reduce ambiguity and token use. It is not the product.

--- a/context/README.md
+++ b/context/README.md
@@ -1,89 +1,52 @@
-# Loaded Vibes Context
+# Hipster Stack Context
 
-This directory tells Codex what Loaded Vibes is, which contracts control the repository, and what active work remains.
+This directory tells Codex what Hipster Stack™ is, which contracts control this repository, and what active work remains.
 
-## Product definition
+## Product
 
-Loaded Vibes is an opinionated project initializer and deterministic software-production tool for modern TypeScript web applications built on the Hipster Stack and Loaded Vibes WebApp Architecture.
+Hipster Stack is an opinionated project initializer and deterministic application-composition tool for modern TypeScript web applications built according to the Codependent Coding™ Knowledge System and the established WebApp architecture.
 
-Its value is the generated repository: a polished white-label application that already contains the recurring architecture, integration boundaries, project structure, and implementation context the builder would otherwise recreate by hand.
+Its payoff is a standalone white-label repository that already contains the recurring architecture, boundaries, integrations, structure, tests, and development context the user would otherwise recreate by hand.
 
-The CLI is the primary execution surface. The web app presents the Product, browsable Libraries/building blocks, the stateless Builder, and canonical end-user Docs. `loadedvibes.json` is the reproducible configuration handoff.
-
-## Current state
-
-The one-template repository migration is complete. The active work is a bounded replacement of the existing website UI/UX using local mockups while preserving the working generator and shared configuration semantics.
+The CLI is the primary local execution adapter. The web app has three coherent surfaces:
 
 ```text
-WORKING PRODUCT
-packages/{cli,core,schema}
-        +
-template/
-        +
-docs/
-        +
-apps/web current UI
-
-              ↓ LV-208..LV-210 only
-
-TARGET WEB SURFACE
-Product      /
-Libraries    /libraries/*
-Builder      /configure
-Docs         /docs/*
-
-same shared schema/core
-same one-template generator
-same CLI handoff
+Product   /
+Docs      /docs/*      # canonical docs + interactive building-block/config views
+Builder   /configure
 ```
 
-Do not reopen the completed generator migration during the UI refresh. Follow LV-208 through LV-210 in order and change non-web code only when a concrete existing contract requires it.
+The Builder, CLI, and portable configuration file must use the same shared semantics.
+
+## Ecosystem
+
+```text
+Codependent Coding Knowledge System
+        ↓
+Hipster Stack generator
+        ↓
+standalone generated application
+        ↓
+Loaded Vibes adaptive spec-driven tool
+        ↓
+product-specific MVP
+```
+
+The Knowledge System is authority, not a runtime dependency. Hipster Stack deterministically materializes the starting application. Loaded Vibes may later adapt that application through governed specifications and agents.
+
+## Current implementation versus approved direction
+
+The live repository still contains historical Loaded Vibes product/package identifiers and the completed LV-201..LV-210 implementation. HS-301..HS-307 are the approved next roadmap and intentionally reconcile that state without pretending the rename/redesign already exists.
+
+Do not reopen unrelated generator migration work during the web overhaul. Change non-web behavior only when the active HS spec explicitly requires it.
 
 ## Source map
 
-### Product and architecture
-
-- `context/docs/product.md`
-- `context/docs/architecture.md`
-- `context/docs/configuration.md`
-- `context/docs/template.md`
-- `context/docs/generator-cli.md`
-
-### Product surfaces
-
-- `context/docs/web.md`
-- `context/docs/documentation.md`
-- local `context/mockups/` visual acceptance inputs for active web Issues
-
-### Release and repository history
-
-- `context/docs/repository-transition.md`
-- `context/docs/release.md`
-
-### Implementation roadmap
-
-- `context/specs/README.md`
-- completed `LV-201` through `LV-207`
-- active `LV-208` through `LV-210`
-
-### Machine-readable boundaries
-
-- `.agents/contracts/product.yaml`
-- `.agents/contracts/architecture.yaml`
-- `.agents/contracts/transition.yaml`
-
-## Engineering doctrine
-
-DevNotes owns canonical Hipster Stack engineering doctrine. The Codependent Coding knowledge system formalizes the same Loaded Vibes WebApp Architecture, layer contracts, technology ownership, and agent-execution method used to build applications.
-
-The applicable grammar is summarized as:
-
-> Routes adapt. Features orchestrate. Components render. Fetchers read. Actions write. Schemas validate. Authorization decides. Transactions preserve invariants. Webhooks reconcile external truth.
-
-For the mostly static Loaded Vibes website surfaces, apply that doctrine proportionally. Use thin App Router routes, server-first presentation composition, and the existing client-side Builder only where local interaction is required. Do not manufacture fetchers/actions/workflows for static content merely to make the directory tree look architectural.
-
-Loaded Vibes owns the executable template and repository-local product behavior. Codependent Coding and DevNotes are doctrine/knowledge authorities, not runtime dependencies.
+- Product/architecture: `context/docs/product.md`, `architecture.md`, `configuration.md`, `template.md`, `generator-cli.md`
+- Web/docs: `context/docs/web.md`, `documentation.md`, `context/mockups/`
+- Machine boundaries: `.agents/contracts/product.yaml`, `.agents/contracts/architecture.yaml`
+- Roadmap: `context/specs/README.md` and active `HS-*` specs
 
 ## Working rule
 
-The active roadmap exists to make the real product look and operate like the approved mockups with the fewest correct edits. Governance should reduce ambiguity and token use, not create a second project beside the product.
+Make the real product look and operate like the approved mockups with the fewest correct edits. Read only active scope, preserve working semantics, remove replaced code, and do not let governance become a second software project.

--- a/context/docs/architecture.md
+++ b/context/docs/architecture.md
@@ -1,190 +1,78 @@
 ---
-title: Loaded Vibes Repository and Generator Architecture
+title: Hipster Stack Repository and Generator Architecture
 artifact: architecture
 status: active
-product: Loaded Vibes
+product: Hipster Stack
 authority: source-of-truth
 ---
 
-# Loaded Vibes Repository and Generator Architecture
+# Hipster Stack Repository and Generator Architecture
 
 ## Core model
 
-Loaded Vibes is a deterministic compiler from a bounded configuration to a filtered and personalized copy of one maximal application template.
+Hipster Stack is a deterministic application-composition system:
 
 ```text
 Web Builder ───────┐
-CLI ──────────────┼──> shared schema + normalization
-loadedvibes.json ─┘                │
-                                   ▼
-                             configuration resolution
-                                   │
-                                   ▼
-                         template ownership catalog
-                                   │
-                                   ▼
-                       retain / remove generation plan
-                                   │
-                                   ▼
-                          one repository template/
-                                   │
-                                   ▼
-                           structured transforms
-                                   │
-                                   ▼
-                       generated white-label project
-                                   │
-                                   ▼
-                           concise user handoff
+CLI ───────────────┼──> shared application-definition schema
+config file ───────┘                 │
+                                     ▼
+                               resolve composition
+                                     │
+                                     ▼
+                               generation plan
+                                     │
+                          ┌──────────┴──────────┐
+                          ▼                     ▼
+                 generator-side catalog   standalone template/
+                          └──────────┬──────────┘
+                                     ▼
+                              materialize output
+                                     │
+                                     ▼
+                           generated application
 ```
 
-## Target repository shape
+The UI/CLI/config file are adapters. They do not own separate configuration semantics.
+
+## Current physical implementation
+
+The live repository currently uses:
 
 ```text
-/
-├── apps/
-│   └── web/                 # / + /libraries/* + /configure + /docs/*
-├── packages/
-│   ├── cli/                 # terminal UX and command adapters
-│   ├── core/                # resolution, planning, generation
-│   └── schema/              # shared loadedvibes.json contract
-├── template/                # one maximal white-label application
-├── docs/                    # canonical end-user docs
-├── context/                 # maintainer/Codex context and visual acceptance inputs
-├── .agents/                 # compact machine contracts and execution state
-├── scripts/                 # package/release utilities actually used
-├── .github/
-└── AGENTS.md
+apps/web
+packages/cli
+packages/core
+packages/schema
+template/
+docs/
+context/
+.agents/
 ```
+
+That is current implementation state, not permission to use `core` as an unlimited responsibility bucket. Future structural changes require their own scoped Issue; the HS web overhaul does not perform a broad generator reorganization.
 
 ## Boundaries
 
-### `packages/schema`
-
-Owns public configuration shapes and enums shared by the CLI, core, and web.
-
-It must not own:
-
-- file-system mutation;
-- terminal UX;
-- web components;
-- template implementation details beyond stable configuration identifiers.
-
-### `packages/core`
-
-Owns:
-
-- defaults and normalization;
-- dependency resolution;
-- template ownership catalog;
-- generation planning;
-- retain/remove decisions;
-- structured personalization;
-- materialization;
-- project provenance/manifest;
-- shared explanations of the generated result.
-
-It must not depend on:
-
-- terminal UI;
-- Next.js web UI.
-
-### `packages/cli`
-
-Owns:
-
-- command parsing;
-- interactive prompts;
-- terminal review and output;
-- invoking the core;
-- user-facing local handoff.
-
-It must not create a second configuration interpretation.
-
-### `apps/web`
-
-Owns:
-
-- the Loaded Vibes Product landing page;
-- the Libraries catalog and library detail presentation metadata;
-- the stateless Builder configuration workbench;
-- a readable preview of normalized/resolved Builder output;
-- rendering canonical end-user documentation;
-- exporting/copying configuration and CLI handoff.
-
-`apps/web` may classify and describe product building blocks for navigation, but it must not duplicate core capability dependencies, fixed/configurable semantics, preset resolution, or recipe validation into a second rules engine.
-
-The web app remains stateless and does not generate projects on a hosted server.
-
-### `template/`
-
-Owns the complete maximal white-label application.
-
-It is executable application source, not a collection of generator fragments.
-
-The template should preserve its working internal architecture. Moving it into `template/` is an ownership and repository-shape cleanup, not permission to rename or reorganize every internal directory.
-
-## One-template composition
-
-The target generator starts from one maximal template and removes material the resolved configuration does not own.
-
-Ownership metadata may express:
-
-- capability/integration identifier;
-- files and directories owned;
-- route groups owned;
-- package or config contributions;
-- environment-example contributions;
-- schema/data contributions where safe removal is supported;
-- structured transforms;
-- dependencies between optional surfaces.
-
-Do not duplicate owned source code into overlay module trees merely to support generation.
-
-## Compatibility during migration
-
-The repository contains `template/` as its sole application source. Preset defaults and optional-surface ownership live in `packages/core`, and generation copies the template before pruning excluded owned routes and applying structured transforms.
-
-They may remain temporarily while earlier specs move source ownership and core semantics. They must not survive as unexplained parallel architecture after the final cleanup spec.
+- Schema/configuration code owns runtime validation and public configuration shapes, not filesystem mutation or UI.
+- Composition/core code owns defaults, dependency/conflict resolution, generator-side template knowledge, generation planning, transforms, materialization, and explanation, not terminal or Next.js presentation.
+- CLI owns command parsing/prompts/output and delegates semantics.
+- Web owns Product, interactive Docs, and Builder presentation. It may own navigation/presentation metadata but not a second capability/configuration rules engine.
+- `template/` owns the standalone maximal white-label application only. Generator ownership catalogs, pruning instructions, CLI/Builder state, and generation mechanics must remain outside it.
 
 ## Application architecture
 
-The generated project preserves the Hipster Stack grammar defined in DevNotes:
+The generated project follows the Codependent Coding/Hipster Stack grammar:
 
-```text
-Routes adapt.
-Features orchestrate.
-Components render.
-Fetchers read.
-Actions receive mutations.
-Schemas validate.
-Workflows coordinate use cases.
-Authorization decides.
-Transactions preserve database invariants.
-Integration adapters own provider mechanics.
-Webhooks reconcile external truth.
-```
+> Routes adapt. Features orchestrate. Components render. Fetchers read. Actions write. Schemas validate. Authorization decides. Transactions preserve invariants. Webhooks reconcile external truth.
 
-Generator internals must not leak into generated application UI.
+Generator internals must not leak into generated application behavior or UI.
 
-## Provenance
+## Generation rules
 
-Generated projects keep minimal local provenance sufficient to explain:
-
-- generator version;
-- template revision;
-- configuration schema version;
-- normalized non-secret configuration;
-- selected optional surfaces;
-- materialization result.
-
-Provenance supports explanation and safe generator-owned follow-up. It is not remote management.
-
-## Safety
-
-- Never fetch an application template from another repository during generation.
-- Never collect provider secrets.
-- Reject unsafe destination behavior.
-- Avoid unsafe shell interpolation.
-- Preserve Windows path behavior.
-- Do not make network/provider calls on behalf of a generated project during basic generation.
+- one repository-owned maximal template;
+- no network template fetch during ordinary generation;
+- every visible selectable option must have a real deterministic generation effect;
+- generator-side metadata may map configuration to owned application artifacts without becoming part of the standalone template;
+- never collect provider secrets;
+- preserve Windows paths and safe destination behavior.

--- a/context/docs/configuration.md
+++ b/context/docs/configuration.md
@@ -1,108 +1,58 @@
 ---
-title: Loaded Vibes Configuration Model
+title: Hipster Stack Configuration Model
 artifact: configuration
 status: active
-product: Loaded Vibes
+product: Hipster Stack
 authority: source-of-truth
 ---
 
-# Loaded Vibes Configuration Model
+# Hipster Stack Configuration Model
 
 ## Principle
 
-Loaded Vibes does not ask users to re-decide the fixed Hipster Stack.
+Configuration describes the application to compose. It does not ask the user to reinvent the engineering method.
 
-Configuration exists for choices that materially change the generated repository and that the generator can honor deterministically.
+Expose an editable property only when Hipster Stack can produce the corresponding repository correctly and deterministically.
 
 ## Shared contract
 
-The CLI, web configurator, and `loadedvibes.json` use one schema and one normalization path.
-
 ```text
 CLI ───────────────┐
-Web ───────────────┼──> schema
-loadedvibes.json ──┘      │
-                          ▼
-                      normalize
-                          │
-                          ▼
-                  resolve dependencies
-                          │
-                          ▼
-                   generation plan
+Web Builder ───────┼──> one runtime schema
+config file ───────┘          │
+                              ▼
+                         normalize/resolve
+                              │
+                              ▼
+                         generation plan
 ```
 
-No surface gets its own hidden defaults or capability semantics.
+No interface gets hidden defaults, dependency rules, or conflicting semantics.
 
-## Recommended configuration categories
+## Configuration categories
 
-### Project
+The target model is organized around the generated application:
 
-- directory;
-- package name;
-- display/product name;
-- description;
-- install dependencies;
-- initialize Git.
+- Project: directory/package/display identity, install, Git initialization.
+- Preset: convenience defaults over the same model.
+- Routes/presentation: supported route surfaces, navigation, semantic visual direction.
+- Identity/access: supported authentication, tenancy, authorization, roles/capabilities/policies when the generator implements those choices.
+- Data/persistence: supported database/ORM/tenant-containment choices when implemented.
+- Integrations/capabilities: supported billing, payments, onboarding, admin, marketing, sample-domain, and other owned application surfaces.
+- Engineering/delivery: supported tests, context/contracts, CI/deployment lifecycle options when deterministically composable.
 
-### Product identity
+Current schema/core support is narrower than this target. Do not expose future choices ahead of generator support.
 
-- brand/display name;
-- description;
-- bounded domain vocabulary when supported.
+## Property model
 
-### Optional application surfaces
+Use a small schema-driven vocabulary where appropriate: boolean, string, single-select, multi-select/collection, mapping/tree/rule. A property may also expose whether its value is default, preset, explicit, required, disabled, or conflicted.
 
-Examples may include:
+Users configure application concepts. Generator-side ownership maps those concepts to files, dependencies, environment examples, transforms, and resources. Individual source files are not normal user-facing controls.
 
-- marketing;
-- onboarding;
-- admin;
-- billing;
-- Stripe Connect;
-- invitations/team management;
-- sample domain;
-- other real route groups present in the master template.
+## Runtime contracts
 
-A surface is configurable only when generation can retain/remove it without leaving knowingly broken imports, routes, package configuration, or setup claims.
+Zod/runtime input validation belongs in schema concerns. Compile-time interfaces/types remain distinct. UI components consume trusted resolved values and do not reinterpret configuration authority.
 
-### Integrations
+## Honesty rule
 
-Expose provider integration choices only when the template has a real supported adapter/boundary and the generator knows the files/configuration it owns.
-
-### Visual direction
-
-Keep this bounded and semantic:
-
-- color family;
-- radius;
-- density;
-- navigation treatment;
-- typography treatment;
-- supported appearance preference where appropriate for generated apps.
-
-Loaded Vibes' own website is dark-only. That does not force generated applications to be dark-only.
-
-## Presets
-
-Presets are optional convenience defaults over the same configuration model.
-
-They are not:
-
-- separate templates;
-- separate architectures;
-- separate application templates.
-
-If existing presets remain useful, move their data into the schema/core boundary during migration.
-
-## Configuration honesty
-
-Do not show a toggle because it sounds useful.
-
-Every selectable option must map to one of:
-
-- a real retain/remove ownership decision;
-- a supported structured transform;
-- a supported project-lifecycle choice.
-
-If not, hide it or label it as fixed/non-configurable until implementation exists.
+No decorative toggles. If a selectable control cannot change real generated output, keep it read-only/hidden until the engine owns that behavior.

--- a/context/docs/documentation.md
+++ b/context/docs/documentation.md
@@ -1,69 +1,25 @@
 ---
-title: Loaded Vibes End-User Documentation
+title: Hipster Stack End-User Documentation
 artifact: documentation
 status: active
-product: Loaded Vibes
+product: Hipster Stack
 authority: source-of-truth
 ---
 
-# Loaded Vibes End-User Documentation
+# Hipster Stack End-User Documentation
 
 ## Canonical source
 
-End-user documentation lives at repository root:
+End-user documentation lives in root `docs/` and is rendered under `/docs/*`. Do not maintain a second technical documentation copy in web code.
 
-```text
-docs/
-```
+## Interactive presentation
 
-The website renders that content under:
+The website may augment canonical docs with browsable building-block categories, related concepts, truthful configuration/status examples, and `Open in Builder` handoffs. Those UI additions are navigation/presentation metadata; shared schema/core remains configuration authority.
 
-```text
-/docs/*
-```
+The previous `/libraries` catalog/detail experience is folded into Docs by HS-305. Preserve old URLs only through the smallest useful redirect/compatibility path.
 
-Do not maintain one documentation copy for GitHub and another copy for the website.
+## Audience and rules
 
-## Audience
+Docs are for developers using Hipster Stack, not Codex maintaining it. Maintainer context remains under `context/`. Application architectural context belongs in the standalone template/generated repository.
 
-The docs are for someone using Loaded Vibes, not for Codex maintaining Loaded Vibes.
-
-Maintainer context stays in `context/`.
-
-Generated-application architectural context stays inside `template/` and the generated repository.
-
-## Initial documentation set
-
-```text
-docs/
-├── index.md
-├── getting-started.md
-├── concepts/
-│   ├── one-template.md
-│   ├── configuration.md
-│   └── generated-project.md
-├── configuration/
-│   ├── project.md
-│   ├── optional-surfaces.md
-│   ├── integrations.md
-│   ├── identity.md
-│   └── design.md
-├── cli/
-│   ├── index.md
-│   ├── create.md
-│   ├── add.md
-│   ├── explain.md
-│   └── doctor.md
-└── troubleshooting.md
-```
-
-Add provider-specific pages only for integrations the released generator actually supports.
-
-## Documentation principles
-
-- Start from what the user is trying to accomplish.
-- Explain fixed architecture only to the degree needed to use the generated project.
-- Do not paste maintainer governance into user docs.
-- Do not claim a provider, route, command, or configuration option works unless the release supports it.
-- Keep setup instructions local and actionable.
-- Keep provider account setup explicitly user-owned.
+Document only providers, commands, routes, configuration fields, and behavior the current release actually supports. Provider account setup remains user-owned.

--- a/context/docs/generator-cli.md
+++ b/context/docs/generator-cli.md
@@ -1,107 +1,51 @@
 ---
-title: Loaded Vibes Generator and CLI
+title: Hipster Stack Generator and CLI
 artifact: generator-cli
 status: active
-product: Loaded Vibes
+product: Hipster Stack
 authority: source-of-truth
 ---
 
-# Loaded Vibes Generator and CLI
+# Hipster Stack Generator and CLI
 
 ## Role
 
-The generator turns a normalized configuration into a local white-label project. The CLI is its primary user-facing execution adapter.
+The generator converts a resolved application definition into a local standalone white-label project. The CLI is its primary local execution adapter.
 
-## Create lifecycle
+## Lifecycle
 
 ```text
-collect or load configuration
-→ normalize
-→ resolve dependencies
-→ present concise review
-→ ensure safe destination
-→ copy maximal template
-→ retain/remove configured ownership
-→ apply structured personalization
-→ write loadedvibes.json and provenance
+collect/load configuration
+→ runtime validate
+→ resolve defaults/dependencies/conflicts
+→ review
+→ safe destination check
+→ materialize maximal template
+→ retain/remove/transform owned artifacts
+→ write portable configuration + provenance
 → install dependencies when requested
 → initialize Git when requested
-→ show concise provider/user next steps
+→ concise handoff
 ```
 
-Do not make ordinary generation depend on live GitHub, provider credentials, or a hosted Loaded Vibes service.
+Ordinary generation must not depend on live GitHub, provider credentials, or a hosted Hipster Stack service.
 
-## CLI vocabulary
+## Naming target
 
-Prefer developer-tool language:
-
-- Configure project
-- Fixed foundation
-- Optional surfaces
-- Integrations
-- Product identity
-- Visual direction
-- Generated output
-
-Avoid:
-
-- Choose your stack
-- Choose your architecture
-- startup-builder marketing language
-- internal generator jargon in normal output
-
-## Command direction
-
-The canonical binary is:
+HS-302 owns the runtime rename. Its target public vocabulary is:
 
 ```text
-loaded-vibes
+hipster-stack create [directory]
+hipster-stack add <supported-surface>
+hipster-stack explain
+hipster-stack doctor
+hipsterstack.json
 ```
 
-Target commands remain small:
+Until HS-302 lands, existing runtime identifiers remain implementation evidence, not competing product doctrine.
 
-```text
-loaded-vibes create [directory]
-loaded-vibes add <supported-surface>
-loaded-vibes explain
-loaded-vibes doctor
-loaded-vibes version
-```
+## CLI responsibility
 
-Keep compatibility aliases only while they materially reduce migration breakage. The release cleanup spec decides what still needs to ship.
+The CLI owns command parsing, prompts, review, progress, and terminal output. It delegates all configuration meaning and generation behavior to shared code and must not create a second resolver.
 
-## `create`
-
-Interactive mode should ask only supported high-leverage configuration.
-
-Config-file mode should use the exact same normalized contract:
-
-```text
-loaded-vibes create my-app --config loadedvibes.json
-```
-
-## `add`
-
-`add` is allowed only for a generator-owned optional surface that has a safe ownership contract for modifying an already generated repository.
-
-The one-template model does not require `add` to disappear, but it does require `add` to stop depending on duplicated module source trees once retain/remove ownership becomes canonical.
-
-Do not promise arbitrary upgrades or merges into user-modified code.
-
-## `explain`
-
-Explain should answer:
-
-- what Loaded Vibes generated;
-- which optional surfaces are present;
-- which integrations are wired;
-- which setup remains user-owned;
-- what fixed architecture the project inherits.
-
-## `doctor`
-
-Doctor remains a small diagnostic helper for local setup and metadata. It should not grow into a conformance framework.
-
-## Output
-
-Terminal output should be compact, legible, and useful. Show implementation details only when they help the user act.
+Keep output concise. Complex configuration may use the portable config file or Builder rather than an absurd forest of dedicated flags.

--- a/context/docs/product.md
+++ b/context/docs/product.md
@@ -1,128 +1,72 @@
 ---
-title: Loaded Vibes Product Definition
+title: Hipster Stack Product Definition
 artifact: product
 status: active
-product: Loaded Vibes
+product: Hipster Stack
 authority: source-of-truth
 ---
 
-# Loaded Vibes Product Definition
+# Hipster Stack Product Definition
 
 ## Product
 
-Loaded Vibes is an opinionated developer tool that turns a bounded technical project configuration into a complete white-label application built from one repository-owned Hipster Stack master template.
-
-A concise product statement is:
+Hipster Stack™ is an opinionated developer tool that turns a bounded application definition into a standalone white-label application derived from one repository-owned maximal template.
 
 > Generate the golden prototype. Start building the product.
 
-Loaded Vibes is not a generic stack chooser and it is not a startup-feature wizard.
+It is not a generic stack marketplace, startup-feature wizard, or hosted control plane.
 
 ## Primary user
 
-The primary user is a developer who already understands the modern TypeScript web stack and wants to stop rebuilding the same foundation, boundaries, routes, integrations, and project structure.
-
-The product should assume familiarity with tools such as Next.js, Prisma, Clerk, Stripe, Postgres, shadcn/ui, GitHub, and Vercel. It should not force the user to re-decide architectural doctrine already encoded by Loaded Vibes.
-
-## Product value
-
-The success metric is the amount of repetitive project setup and foundational implementation the generated repository removes.
-
-The Builder being attractive matters. The CLI being pleasant matters. The decisive payoff is:
-
-> How much useful, correct application did the user receive before writing product-specific code?
+The primary user is a developer who already understands the underlying technologies and wants to stop rebuilding the same architecture, boundaries, routes, integrations, and project structure.
 
 ## Product surfaces
 
-1. **Master template** — the maximal white-label application source owned by this repository.
-2. **Configuration contract** — the bounded project choices Loaded Vibes can actually honor.
-3. **Core generator** — deterministic resolution, retain/remove ownership, transforms, materialization, and provenance.
-4. **CLI** — primary execution surface.
-5. **Web Product page** — concise explanation and entry point at `/`.
-6. **Web Libraries** — browsable catalog and detail pages for Loaded Vibes building blocks at `/libraries/*`.
-7. **Web Builder** — stateless visual configuration workbench at `/configure`.
-8. **End-user docs** — canonical `docs/` content rendered under `/docs/*`.
-9. **`loadedvibes.json`** — portable configuration handoff.
-10. **Generated application** — the actual product value.
+1. maximal standalone template;
+2. shared configuration/application-definition contract;
+3. deterministic composition/generation engine;
+4. CLI;
+5. Product web page at `/`;
+6. interactive Docs at `/docs/*` combining canonical documentation with browsable building-block/configuration views;
+7. stateless Builder at `/configure`;
+8. portable configuration handoff, targeted by HS-302 as `hipsterstack.json`;
+9. generated application.
 
-## Fixed foundation
+## Opinionated foundation
 
-The stack and application grammar are Loaded Vibes decisions rather than configuration questions.
+Hipster Stack fixes the engineering method and supported architectural grammar rather than forcing users to rediscover them:
 
-The fixed foundation is the repository-supported implementation of:
+- server-owned business truth and explicit trust boundaries;
+- route → feature → presentation layering;
+- protected read/mutation boundaries;
+- runtime validation at trust boundaries;
+- explicit authorization, persistence, transaction, provider, and webhook responsibilities;
+- strong separation of concerns and narrow typed interfaces;
+- generated repositories that remain understandable to humans and agents.
 
-- TypeScript;
-- Next.js App Router;
-- React Server Components by default;
-- pnpm;
-- Zod;
-- Prisma;
-- Neon/PostgreSQL;
-- Clerk identity/session boundary;
-- application-owned users, organizations, memberships, roles/capabilities, and authorization;
-- tenant containment including RLS where the template implements it;
-- Fetchers;
-- Server Actions;
-- Workflows;
-- Transactions;
-- Selects;
-- DTO mappers;
-- Integration Adapters;
-- webhook processors;
-- shadcn-compatible UI primitives and composed presentation;
-- Vercel-oriented deployment.
+Concrete providers, route surfaces, authorization models, integrations, capabilities, and product configuration are selectable only when the shared schema and generator have deterministic support for that choice. Current implementation limitations remain authoritative until changed by an implementation Issue.
 
-Do not ask users to choose a different implementation of these within the current product.
+## Template payoff
 
-## Configuration
+The template is a maximal runnable application, not generator source code. Generator ownership/pruning metadata lives outside the template. Application-local tests, docs, CI, and agent contracts may remain when they govern the application itself.
 
-Configuration should be technical, bounded, and real.
+## Ecosystem
 
-A choice belongs in the product only when the template and generator can correctly retain, remove, configure, or personalize its owned output.
-
-Useful configuration categories include:
-
-- project name/directory/package metadata;
-- install and git-init behavior;
-- optional integration surfaces;
-- optional route groups and route surfaces;
-- optional reusable product capabilities backed by owned code;
-- product identity and bounded domain vocabulary;
-- semantic visual direction.
-
-Presets may remain as convenience defaults if useful, but they are not separate templates and they are not the center of the product.
-
-The Libraries and Builder web surfaces may explain fixed foundation choices, but fixed choices must remain read-only rather than becoming decorative configuration.
+```text
+Codependent Coding™ Knowledge System
+  canonical reusable engineering knowledge
+        ↓
+Hipster Stack™
+  deterministic golden-prototype generation
+        ↓
+Generated application
+        ↓
+Loaded Vibes™
+  adaptive specification-driven implementation
+        ↓
+Product-specific MVP
+```
 
 ## Non-goals
 
-Loaded Vibes is not:
-
-- a universal app generator;
-- an arbitrary framework selector;
-- a provider marketplace;
-- a plugin marketplace;
-- a hosted build/control plane;
-- an account-based SaaS around the configurator;
-- an enterprise policy/governance platform;
-- a validation product;
-- an autonomous arbitrary upgrade/merge engine;
-- a replacement for product-specific implementation after generation.
-
-## Relationship to other systems
-
-```text
-DevNotes
-  owns Hipster Stack knowledge
-
-Loaded Vibes
-  owns deterministic production and the executable template
-
-Generated project
-  owns the product codebase produced for the user
-
-Codependent Coding
-  may guide adaptive product-specific development after generation
-```
-
-No external application repository is a template dependency.
+Hipster Stack is not an arbitrary framework selector, provider/plugin marketplace, hosted build service, account-based configurator SaaS, autonomous upgrade/merge engine, or replacement for product-specific implementation after generation.

--- a/context/docs/template.md
+++ b/context/docs/template.md
@@ -1,72 +1,33 @@
 ---
-title: Loaded Vibes Master Template
+title: Hipster Stack Maximal White-Label Template
 artifact: template
 status: active
-product: Loaded Vibes
+product: Hipster Stack
 authority: source-of-truth
 ---
 
-# Loaded Vibes Master Template
+# Hipster Stack Maximal White-Label Template
 
 ## Definition
 
-Loaded Vibes owns one maximal white-label application template.
+Hipster Stack owns one maximal standalone white-label application at `template/`.
 
-The template is the best reusable version of the application architecture this system repeatedly builds. It contains the supported foundation, route surfaces, integration boundaries, reusable application infrastructure, presentation, and scoped agent context.
+The template is the best reusable version of the application architecture repeatedly built from the Codependent Coding Knowledge System. It contains application routes, features, presentation, server operations, data/persistence, integrations, tests, deployment setup, and scoped application/agent context when those belong to the application itself.
 
-The template is not an example project and it is not a pile of independent templates.
+## Hard boundary
 
-## Authority
+The template is the product source, not generator machinery.
 
-- Loaded Vibes owns the executable template.
-- DevNotes owns the Hipster Stack engineering doctrine used to maintain it.
-- Codependent Coding is not required to generate the template.
+It must not contain generator ownership catalogs, retain/remove instructions, Builder state, CLI implementation, generation planning, or Hipster Stack-only metadata whose only purpose is to tell the generator how to construct it. That information belongs upstream in the generator.
 
-## Target location
+The template should remain runnable and conceptually complete if extracted from this monorepo.
 
-```text
-template/
-```
+## Maximal means supported
 
-The target is singular by design.
+A surface belongs in the maximal template only when a real working implementation exists. Proposed future providers/capabilities do not become configurable merely because governance names them.
 
-The repository-owned application lives at `template/`. Retain/remove ownership for optional surfaces lives in the generator core.
+## Application grammar
 
-## Maximal means supported, not imaginary
+The template preserves the established method and boundaries from DevNotes. Concrete optional modules/providers may become composable only when the generator has an explicit deterministic ownership contract for them.
 
-The template may contain optional surfaces only when they have real repository-owned implementation.
-
-Do not add placeholder architecture simply because a future generator could conceivably support it.
-
-If a provider or route surface is only proposed and not actually implemented, it does not become configurable merely because governance names it.
-
-## Fixed application foundation
-
-The template should keep the canonical application grammar and core identity/tenancy/security model intact.
-
-The fixed foundation includes the supported implementation of:
-
-- application shell and root route behavior;
-- authentication boundary;
-- tenant shell;
-- local application identity;
-- organizations and memberships;
-- RBAC/capability authorization;
-- database boundary and tenant containment;
-- Server Action, Fetcher, Workflow, Transaction, Select, DTO, Integration Adapter, and Webhook patterns;
-- shared presentation primitives;
-- configuration/environment boundaries.
-
-## Optional ownership
-
-Optional material may include real supported integration or route/capability surfaces such as billing, Stripe Connect, marketing, onboarding, admin, sample domain, uploads/media, inference, or mapping only to the extent the template actually contains working source for them.
-
-The generator later decides whether to retain or remove them.
-
-## Scoped agent context
-
-Agent guidance belongs near stable architectural boundaries when it materially helps future implementation.
-
-Use scoped `AGENTS.md` files for durable route/layer guidance. Do not litter runtime components with explanatory architecture prose that belongs in context.
-
-Generated UI should look like a product, not like documentation about the stack.
+Generated application UI must look like a product, not documentation about the generator.

--- a/context/docs/web.md
+++ b/context/docs/web.md
@@ -1,205 +1,70 @@
 ---
-title: Loaded Vibes Website and Configurator
+title: Hipster Stack Website and Builder
 artifact: web
 status: active
-product: Loaded Vibes
+product: Hipster Stack
 authority: source-of-truth
 ---
 
-# Loaded Vibes Website and Configurator
+# Hipster Stack Website and Builder
 
 ## Product role
 
-The web app presents Loaded Vibes as a coherent developer product and gives users a stateless visual configuration surface over the same configuration contract used by the CLI.
-
-It has four jobs:
-
-1. explain the product concisely;
-2. expose the Loaded Vibes system as browsable libraries/building blocks;
-3. let users compose a supported configuration visually;
-4. render the canonical end-user documentation from `docs/`.
-
-It is not a hosted project-control product, generic stack marketplace, or marketing site that invents choices the generator cannot honor.
-
-## Routes and navigation
+The web app is a developer tool with three coherent surfaces:
 
 ```text
-/                    Product / landing page
-/libraries           library/building-block catalog
-/libraries/[slug]    individual library/building-block detail
-/docs/*              end-user Loaded Vibes documentation
-/configure            Builder visual configuration workbench
+/            Product
+/docs/*      canonical + interactive Docs
+/configure   Builder
 ```
 
-Primary navigation:
+Legacy `/libraries` URLs may redirect into Docs during HS-305. No account system, hosted project database, billing product, or remote generation backend is required.
+
+## Visual acceptance
+
+`context/mockups/landing.png`, `libraries.png`, `config.png`, and `builder.png` are presentation authority for the current overhaul. Reproduce their structure, hierarchy, density, spacing, dark panels, control geometry, typography emphasis, restrained cyan glow, and Digital Herencia desert/circuit composition faithfully.
+
+Mockups are not semantic authority. Correct illustrative labels/options when they conflict with actual repository-supported behavior.
+
+## Brand lock
+
+- near-black canvas and white primary text;
+- primary cyan around `#48c8c8`, with only minimal accessible supporting teal/cyan values;
+- restrained glow, thin hard-edged borders, no violet/magenta competing system;
+- Big Shoulders Display (heavy/condensed) or the closest build-safe equivalent for the Hipster Stack wordmark/display headings; clean sans-serif body/UI type;
+- use `public/Digital Herencia Desert BG.png` as an intentional lower-page horizon/transition with controlled crop/fade;
+- keep Digital Herencia secondary to the Hipster Stack product identity.
+
+## BoldKit
+
+Use actual React source from the `ANIBIT14/boldkit` GitHub/shadcn registry as locally owned presentation source. Import the approved primitive set to `apps/web/components/ui/` and only the blocks needed by the mockups to `components/blocks/`. Adapt tokens/composition to the Hipster Stack mockups. Do not depend on BoldKit at runtime and do not inherit its stock aesthetic.
+
+## TanStack reference
+
+TanStack is an interaction reference only: compact selections, clear button hierarchy, browsable categories, inspectable configuration/generated-plan consequences, and obvious Builder handoff. Do not copy TanStack styling or introduce unrelated TanStack libraries.
+
+## Architecture
+
+For these primarily public/static surfaces use the proportional application grammar:
 
 ```text
-Product | Libraries | Docs | Builder
+route/page → feature orchestration → pure blocks/components → UI primitives
 ```
 
-`Builder` links to `/configure`; do not rename a working route merely to make the URL literal.
+Pages/layouts stay thin and Server Components by default. Builder owns a deliberate local client island. Pure presentation owns no shared configuration authority, protected I/O, Prisma, provider SDKs, or generator side effects.
 
-No Loaded Vibes account system, hosted project database, Loaded Vibes billing system, or remote build backend is required.
+## Product
 
-## Visual acceptance contract
+The landing page follows `landing.png`; Builder is the primary CTA and Docs is the secondary exploration path. Use truthful generator copy and no unsupported options.
 
-The current web replacement is mockup-driven. The implementation working tree contains a local `context/mockups/` directory with four visual subjects:
+## Interactive Docs
 
-- Product/landing page;
-- Libraries catalog;
-- individual library/configuration detail page;
-- Builder.
-
-Codex must inspect that directory and map the actual files by their visual content before editing. Do not assume filenames and do not continue if the required mockup subject is missing.
-
-The mockups are the design standard. Faithfully reproduce their:
-
-- page structure and section order;
-- visual hierarchy and information density;
-- spacing and proportions;
-- dark surfaces and border treatment;
-- typography scale and emphasis;
-- navigation placement;
-- card composition;
-- restrained teal/cyan glow;
-- Loaded Vibes and Digital Herencia brand placement;
-- desert/circuit footer treatment;
-- interaction model implied by controls and links.
-
-Do not reinterpret them into another aesthetic, generic SaaS template, or personal redesign.
-
-The mockups are **presentation authority, not semantic authority**. Apply product judgment when literal text or controls would contradict the real product. Button/control labels, JSON examples, category wording, and link targets may be adjusted to describe actual Loaded Vibes behavior. Preserve the depicted design and interaction purpose while replacing illustrative nonsense with the correct repository-supported action.
-
-Never implement a fake toggle, fake provider choice, fake recipe field, or fake output merely because it appears illustratively in a mockup. Shared schema/core and current repository behavior remain authoritative for functionality.
-
-## Brand and visual direction
-
-Loaded Vibes is dark-only.
-
-Use the established brand family:
-
-- near-black canvas;
-- white primary type;
-- muted teal/cyan centered on `#2f7a8d` and closely related accessible tones;
-- restrained glow rather than neon saturation;
-- thin bordered dark panels;
-- Big Shoulders-style condensed display treatment for major Loaded Vibes headings where available;
-- clean sans-serif UI/body typography;
-- Loaded Vibes crown/circuit motif as a controlled brand device;
-- Digital Herencia desert/circuit landscape as a lower-page/footer device;
-- Digital Herencia parent-brand lockup kept secondary to Loaded Vibes.
-
-Avoid violet/magenta-heavy styling, beige editorial styling, startup-confetti aesthetics, excessive gradients, partner grids, decorative dashboard density, and marketing sections that do not improve product comprehension.
-
-Preserve the repository-root `public/` brand assets and their source images. The website may consume them through the smallest build-compatible approach, but must not delete that directory merely because the Next.js app lives under `apps/web`.
-
-## Architecture and implementation method
-
-The UI replacement must remain recognizably built according to the Codependent Coding knowledge system, Hipster Stack, and Loaded Vibes WebApp Architecture. The canonical architectural grammar is:
-
-```text
-Routes adapt.
-Features orchestrate.
-Components render.
-Fetchers read.
-Actions write.
-Schemas validate.
-Authorization decides.
-Transactions preserve invariants.
-Webhooks reconcile external truth.
-```
-
-For these mostly static/product-presentation surfaces, use the applicable subset rather than ceremonial layers:
-
-```text
-route/page -> feature/presentation orchestration -> shared/domain presentation
-```
-
-- keep App Router pages/layouts thin;
-- default to Server Components;
-- create a client boundary only where browser interaction/local state requires one, chiefly Builder;
-- keep pure presentation free of protected I/O, provider SDKs, Prisma, or product authority;
-- reuse the existing browser-safe `@loaded-vibes/core` contract for Builder semantics;
-- do not add fetchers/actions/workflows when the page has no protected read or mutation just to satisfy a diagram;
-- do not turn a focused website refactor into a repository-wide architecture migration.
-
-Relevant doctrine sources are the Codependent Coding knowledge system (`docs/10-loaded-vibes-architecture.md`, `docs/11-hipster-stack-tech-map.md`, `docs/12-layer-contracts.md`, `docs/18-agent-execution.md`) and the mirrored canonical Loaded Vibes architecture source in DevNotes. Local repository governance controls when it is more specific.
-
-## Product landing page
-
-The landing mockup should communicate with minimal copy:
-
-- Loaded Vibes generates a serious production-minded SaaS starting point;
-- the user chooses bounded product/configuration differences rather than architecture;
-- Builder is the primary interactive CTA;
-- Libraries exposes the product building blocks;
-- Docs is the canonical end-user reference;
-- the output is a real generated repository owned by the user.
-
-The hero/product preview may summarize Builder state, but must not expose fake provider choices or unsupported configuration.
-
-## Libraries
-
-`/libraries` is a browsable product-building-block catalog, not a package registry and not a generic technology catalog.
-
-The visual mockup groups concepts under a small number of categories such as Foundation, Identity, Data, Revenue, and Interface. The actual concepts and descriptions must represent the way Loaded Vibes applications are built under the Loaded Vibes architecture and Hipster Stack.
-
-Presentation metadata may be web-owned, but configuration truth comes from existing repository sources where available:
-
-- `packages/core/src/capabilities.ts` for capability labels, dependencies, and fixed/configurable status;
-- `packages/core/src/presets.ts` for real product presets;
-- `packages/schema/src/recipe.ts` for valid recipe fields;
-- Loaded Vibes fixed-foundation governance for non-configurable architectural elements.
-
-Do not duplicate dependency/fixed semantics in a second web-only rules engine.
-
-Individual library pages make configuration/status the primary useful content. A configurable capability may show the smallest valid `loadedvibes.json` example needed to enable it. A fixed-foundation library must be identified as fixed/included rather than exposing a decorative toggle or fake provider selector. Related-library links are presentation/navigation metadata only.
+HS-305 folds the old Libraries experience into Docs. `docs/` remains canonical end-user content. Web metadata may organize categories, relationships, configuration examples/status, and `Open in Builder` actions, but must not become another configuration rules engine.
 
 ## Builder
 
-`/configure` is the Builder.
-
-The Builder follows the Builder mockup: a compact configuration surface paired with a readable recipe/result preview. It should feel like composing a supported Loaded Vibes starting point, not completing a long wizard and not shopping for architecture.
-
-Preserve existing stateless product-valid behavior:
-
-- shared schema/core resolution;
-- real product presets;
-- real configurable modules/capabilities;
-- product identity fields;
-- bounded design fields;
-- copy/download of `loadedvibes.json`;
-- copyable CLI handoff;
-- shareable serialized configuration if it remains cheap and working.
-
-Fixed architecture and fixed capabilities may be shown as read-only selected/included items for comprehension, but never as user-switchable choices.
-
-The result panel must show actual normalized configuration and resolved inclusions. A representative generated-app preview may be removed when it duplicates the mockup-driven recipe/result experience and no longer adds product value.
-
-## Docs
-
-`/docs/*` remains a conventional end-user documentation experience backed by canonical content in `docs/`.
-
-The docs renderer does not need a bespoke mockup-driven content redesign. It should share the global brand/navigation shell where practical without making documentation harder to read or introducing decorative product-page density.
-
-## Output and statelessness
-
-The Builder may provide:
-
-- `loadedvibes.json` copy/download;
-- a copyable CLI command;
-- a shareable local/URL representation when already supported;
-- a readable summary of resolved output.
-
-It does not perform local generation on the hosted website.
+The Builder follows `builder.png`: dense two-panel workbench, schema-backed controls left, inspectable resolved configuration/output right. Preserve current working resolver/serialization/download/copy/share behavior through the HS-302 rename. Only actual supported properties are editable.
 
 ## Implementation economy
 
-For the mockup replacement:
-
-- inspect first, then make the smallest complete refactor;
-- prefer reusing current routes, config helpers, and browser-safe core;
-- introduce only shared components that remove real duplication or enforce the established presentation hierarchy;
-- delete obsolete CSS/components/helpers immediately after their final caller is replaced;
-- do not add a UI framework, icon package, animation library, design-token subsystem, backend, or new validation harness merely to reproduce the mockups;
-- run only the existing web checks that directly establish the changed behavior.
+Reuse current routes/helpers/shared semantics. Introduce only components that remove real duplication or enforce presentation responsibilities. Delete obsolete CSS/components/helpers immediately after their final caller is replaced. Add no backend, CMS, analytics project, animation library, or new validation harness for this overhaul. Run only the focused checks named by the active spec.

--- a/context/specs/HS-301-governance-product-identity.md
+++ b/context/specs/HS-301-governance-product-identity.md
@@ -1,0 +1,41 @@
+---
+id: HS-301
+title: Reconcile Hipster Stack identity and web-overhaul governance
+status: active
+type: implementation-spec
+order: 301
+depends_on: []
+issue: 135
+---
+
+# HS-301 — Governance and product identity
+
+## Outcome
+
+Make active governance describe the approved ecosystem and mockup-driven Hipster Stack web overhaul before runtime implementation begins.
+
+## Required inputs
+
+Read only `AGENTS.md`, `context/README.md`, `context/docs/{product,architecture,configuration,template,generator-cli,web,documentation}.md`, `.agents/contracts/{product,architecture}.yaml`, `context/specs/README.md`, and Issue #135.
+
+## Required decisions
+
+- Codependent Coding™ is the upstream Knowledge System.
+- Hipster Stack™ is this deterministic generator/CLI/web product.
+- Loaded Vibes™ is downstream adaptive specification-driven development tooling.
+- The template is a standalone application and contains no generator-only machinery.
+- The method/boundaries stay opinionated; concrete choices are editable only when generator support exists.
+- Web navigation target is `Product | Docs | Builder`; Libraries folds into interactive Docs.
+- Mockups control presentation, shared code controls semantics, BoldKit supplies locally owned UI source, TanStack is interaction reference only.
+
+## Non-goals
+
+No runtime code, package rename, repository rename, UI implementation, deployment, provider operation, or test-system work.
+
+## Acceptance
+
+Active owner docs/contracts no longer conflict on product identity, ecosystem boundary, web surfaces, template boundary, or configuration honesty. Historical `LV-*` material remains provenance.
+
+## Verification
+
+Read back changed governance and compare branch against master. No application test suite is required for governance-only changes.

--- a/context/specs/HS-302-rename-generator-identifiers.md
+++ b/context/specs/HS-302-rename-generator-identifiers.md
@@ -1,0 +1,39 @@
+---
+id: HS-302
+title: Rename active generator identifiers to Hipster Stack
+status: active
+type: implementation-spec
+order: 302
+depends_on: [HS-301]
+issue: 136
+---
+
+# HS-302 — Rename active generator identifiers
+
+## Outcome
+
+Rename active product/runtime identifiers to Hipster Stack without rewriting history or renaming the GitHub repository.
+
+## Required inputs
+
+Read this spec, Issue #136, `context/docs/{product,configuration,generator-cli,web}.md`, `.agents/contracts/product.yaml`, root/workspace package metadata, CLI entry files, shared configuration code, active web copy, and directly affected tests. Use repository search rather than broad file-by-file reading.
+
+## Target vocabulary
+
+- product: Hipster Stack™
+- canonical CLI: `hipster-stack`
+- portable config: `hipsterstack.json`
+- workspace namespace: `@hipster-stack/*`
+- Loaded Vibes™ only when referring to downstream adaptive tooling
+
+## Rules
+
+Preserve historical closed issues/PRs/specs. Do not rename the GitHub repository. Keep an old command/package alias only if repository evidence demonstrates a real compatibility obligation; otherwise remove stale aliases instead of carrying ambiguity forward.
+
+## Non-goals
+
+No UI redesign, generator architecture rewrite, template restructuring, npm publication, deployment, or provider changes.
+
+## Verification
+
+Run only focused typecheck/build and directly affected CLI/configurator tests plus an active-reference search.

--- a/context/specs/HS-303-web-design-foundation.md
+++ b/context/specs/HS-303-web-design-foundation.md
@@ -1,0 +1,43 @@
+---
+id: HS-303
+title: Establish BoldKit-backed Hipster Stack web design foundation
+status: active
+type: implementation-spec
+order: 303
+depends_on: [HS-301, HS-302]
+issue: 137
+---
+
+# HS-303 — Web design foundation
+
+## Outcome
+
+Create the minimal reusable presentation foundation required by the approved mockups using locally owned BoldKit source and the Hipster Stack/Digital Herencia brand family.
+
+## Required inputs
+
+Read this spec, Issue #137, `context/docs/web.md`, all four mockups for cross-page consistency, current `apps/web` package/CSS/header/footer, Vouch `components.json` only for the existing `@boldkit` registry precedent, and only BoldKit source needed for the approved primitives/blocks.
+
+## Design lock
+
+- near-black canvas, white text, primary cyan approximately `#48c8c8`;
+- Big Shoulders Display heavy/condensed wordmark/display treatment or closest build-safe equivalent; clean sans body/UI;
+- thin hard-edged dark panels and restrained glow;
+- Digital Herencia Desert BG used as a controlled lower-page horizon with fade/crop;
+- mockups remain visual authority.
+
+## BoldKit
+
+Add shadcn-compatible web registry configuration. Import the approved React UI primitives as locally owned `apps/web/components/ui` source. Adapt only blocks actually used by the mockups into `components/blocks`. Add exact required dependencies only. No runtime dependency on the GitHub repository and no stock BoldKit redesign.
+
+## Architecture
+
+Primitives and blocks are pure presentation. They do not own configuration resolution, protected I/O, or generator semantics.
+
+## Non-goals
+
+No Product/Docs/Builder full-page implementation, generator changes, animation framework, or new validation system.
+
+## Verification
+
+Web typecheck/build plus desktop and narrow focused inspection of the new foundation.

--- a/context/specs/HS-304-web-shell-landing.md
+++ b/context/specs/HS-304-web-shell-landing.md
@@ -1,0 +1,41 @@
+---
+id: HS-304
+title: Rebuild Product shell and landing from approved mockup
+status: active
+type: implementation-spec
+order: 304
+depends_on: [HS-302, HS-303]
+issue: 138
+---
+
+# HS-304 — Product shell and landing
+
+## Outcome
+
+Faithfully implement `context/mockups/landing.png` under Hipster Stack branding using the HS-303 design foundation.
+
+## Required inputs
+
+Read this spec, Issue #138, `context/docs/web.md`, `landing.png`, and only current shell/Product files plus direct presentation dependencies.
+
+## Architecture guardrail
+
+`app/page.tsx` remains thin and server-first. The Product feature composes pure blocks/components. Do not introduce protected I/O or generator semantics into presentation.
+
+## Required composition
+
+Preserve the mockup's brand moment, two-column introduction/Builder preview, compact entry cards, workflow strip, foundation summary, spacing/proportions, and cyan/black treatment. Navigation is `Product | Docs | Builder`. Use truthful generator copy and CTA labels. Use the Hipster Stack wordmark. Integrate the Digital Herencia Desert BG as the lower horizon/footer transition.
+
+Use BoldKit blocks only where they reduce code without changing the mockup's composition.
+
+## Cleanup
+
+Delete replaced old branding markup/styles/components after their last caller is gone.
+
+## Non-goals
+
+No backend state, new configuration choices, generator/schema/template change, or unrelated marketing content.
+
+## Verification
+
+`pnpm --dir apps/web typecheck`, `pnpm --dir apps/web build`, desktop mockup comparison, one narrow-width inspection, and direct CTA/navigation smoke.

--- a/context/specs/HS-305-interactive-docs.md
+++ b/context/specs/HS-305-interactive-docs.md
@@ -1,0 +1,36 @@
+---
+id: HS-305
+title: Merge Libraries and Docs into interactive documentation
+status: active
+type: implementation-spec
+order: 305
+depends_on: [HS-302, HS-303, HS-304]
+issue: 139
+---
+
+# HS-305 — Interactive Docs
+
+## Outcome
+
+Create one simple Docs experience that combines canonical Markdown documentation with the useful browsable/configuration behavior implied by the Libraries and config-detail mockups.
+
+## Required inputs
+
+Read this spec, Issue #139, `context/docs/{web,documentation,configuration}.md`, `context/mockups/{libraries,config}.png`, the existing docs renderer, Libraries feature/data, and only shared Builder/configuration code needed to prevent semantic duplication.
+
+## Required behavior
+
+- `/docs` is the primary documentation destination and includes a browsable functional-area/building-block overview.
+- Detail views combine concise canonical explanation, real fixed/configurable status/example, related concepts, and `Open in Builder` when meaningful.
+- `docs/` Markdown remains canonical technical content.
+- Reuse shared configuration semantics; no second capability/dependency engine.
+- Preserve old `/libraries` URLs through the smallest redirect/compatibility route, then remove Libraries-only code with no caller.
+- Use the mockup aesthetic and HS-303 components. TanStack informs browse/detail/action ergonomics only.
+
+## Non-goals
+
+No docs framework/CMS, fake controls, unsupported provider/configuration claims, backend state, or broad content rewrite.
+
+## Verification
+
+Web typecheck/build and route smoke for `/docs`, one fixed concept, one configurable concept, one legacy `/libraries` URL, Builder handoff, and one narrow layout.

--- a/context/specs/HS-306-web-builder-composition.md
+++ b/context/specs/HS-306-web-builder-composition.md
@@ -1,0 +1,51 @@
+---
+id: HS-306
+title: Rebuild Builder as schema-driven composition workbench
+status: active
+type: implementation-spec
+order: 306
+depends_on: [HS-302, HS-303]
+issue: 140
+---
+
+# HS-306 — Builder composition workbench
+
+## Outcome
+
+Refactor `/configure` into the approved dense two-panel Builder while preserving one shared configuration authority and existing working semantics.
+
+## Required inputs
+
+Read this spec, Issue #140, `context/docs/{web,configuration}.md`, `builder.png`, current `Configurator`, web configurator helper, shared capability/preset/schema files, and directly affected test/CSS/components only.
+
+Do not crawl the template or unrelated generator code unless an actual semantic contradiction blocks acceptance.
+
+## Architecture
+
+```text
+/configure route
+  → Builder feature/client orchestration
+    → pure Builder controls/blocks
+      → BoldKit UI primitives
+    → browser-safe shared configuration resolver
+```
+
+The client island owns local draft/UI state only. Shared code owns valid values, dependencies, conflicts, normalization, and generated output meaning.
+
+## UI/functionality
+
+Preserve the mockup's left controls/right inspectable result layout. Organize visible controls around generated-application concerns using only currently supported fields. Reuse generic property-control shapes where useful, but do not create ceremony. Right panel shows actual normalized `hipsterstack.json`, resolved/required capability consequences, CLI handoff, and output summary. Preserve working download/copy/share behavior if still cheap.
+
+TanStack may inform compact control hierarchy and inspectable-plan behavior; mockup styling remains authoritative.
+
+## Cleanup
+
+Remove hardcoded web-only option/rule duplication and replaced Builder CSS/helpers after final callers disappear.
+
+## Non-goals
+
+No fake future à-la-carte options, hosted generation, account/backend state, template rewrite, provider changes, or new validation system.
+
+## Verification
+
+Web typecheck/build, directly affected configurator unit test, representative preset/dependency/edit/copy/share actions, desktop comparison, and one narrow-width check.

--- a/context/specs/HS-307-web-cleanup-conformance.md
+++ b/context/specs/HS-307-web-cleanup-conformance.md
@@ -1,0 +1,38 @@
+---
+id: HS-307
+title: Remove superseded web code and run focused UI conformance
+status: active
+type: implementation-spec
+order: 307
+depends_on: [HS-304, HS-305, HS-306]
+issue: 141
+---
+
+# HS-307 — Web cleanup and conformance
+
+## Outcome
+
+Finish the overhaul by deleting superseded web code and proving the focused Product/Docs/Builder result without expanding into a repository-wide validation project.
+
+## Required inputs
+
+Read this spec, Issue #141, changed web files/direct imports from HS-304..HS-306, active `context/docs/web.md`, and the mockups. Expand only for a concrete failure.
+
+## Cleanup
+
+- delete dead Libraries-only presentation after redirects exist;
+- delete replaced old generator branding, wordmark cropping, custom icons, obsolete Builder helpers, and CSS/tokens with no caller;
+- dedupe only proven duplicate presentation responsibilities;
+- search active web/runtime content for incorrect generator references to Loaded Vibes while preserving historical and legitimate downstream references.
+
+## Conformance
+
+Verify Product, interactive Docs, Builder, shared shell, wordmark, and desert horizon are one coherent responsive system. Verify visible actions/links are real and no illustrative dead control remains.
+
+## Non-goals
+
+No broad refactor, dependency upgrade, new tests/screenshots framework, generator/template migration, or deployment.
+
+## Verification
+
+Web typecheck, web build, directly affected configurator test, route/action smoke, desktop mockup comparison, and one narrow-width check. Report unrun checks truthfully.

--- a/context/specs/README.md
+++ b/context/specs/README.md
@@ -1,47 +1,37 @@
-# Loaded Vibes Implementation Specs
+# Hipster Stack Implementation Specs
 
-GitHub Issues are the operational queue. Each active implementation Issue corresponds to one focused spec. The spec is durable scope and acceptance context, not a second project-management system.
+GitHub Issues are the operational queue. Each active implementation Issue maps to one focused spec. Specs are durable scope/acceptance context, not a second project-management system.
 
-## Completed one-template migration
-
-1. **LV-201** — consolidate the one repository-owned master template.
-2. **LV-202** — simplify configuration and absorb recipe ownership.
-3. **LV-203** — convert generation to one-template retain/remove ownership.
-4. **LV-204** — split the developer-tool landing page and configurator.
-5. **LV-205** — add canonical end-user docs and `/docs`.
-6. **LV-206** — polish the CLI/package around the final model.
-7. **LV-207** — remove migration debris and prepare the coherent release.
-
-## Active mockup-driven web refresh
-
-The current web UI/UX replacement is deliberately only three implementation units:
-
-1. **LV-208** — replace the shared shell and Product landing page from the local mockup.
-2. **LV-209** — add the Libraries catalog and linked detail pages from the local mockups.
-3. **LV-210** — refactor the Builder around the local mockup, preserve real config semantics, and remove replaced web code.
+## Current roadmap
 
 ```text
-LV-208 shell + Product
-          │
-          ▼
-LV-209 Libraries + detail
-          │
-          ▼
-LV-210 Builder + final web cleanup
+HS-301 governance + ecosystem boundary
+        ↓
+HS-302 active product/runtime rename
+        ↓
+HS-303 BoldKit + brand/design foundation
+        ├───────────────┐
+        ▼               ▼
+HS-304 Product       HS-306 Builder
+        │               │
+        └──────┬────────┘
+               ▼
+         HS-305 interactive Docs
+               │
+               ▼
+         HS-307 cleanup/conformance
 ```
 
-This sequence is intentionally small. Do not split it further unless an actual blocked dependency makes one Issue unreviewable.
+HS-304 and HS-306 may proceed in parallel after their dependencies are satisfied. HS-305 consumes the shared shell/design and shared Builder/configuration presentation. HS-307 is final cleanup only.
 
 ## Visual authority
 
-For LV-208 through LV-210, the local `context/mockups/` subjects are the visual acceptance artifacts. `context/docs/web.md` defines how to interpret them: reproduce design/structure faithfully, but adapt literal labels and controls when needed to implement truthful Loaded Vibes behavior.
+The local `context/mockups/` files are visual acceptance artifacts. Preserve their structure/aesthetic while correcting illustrative text/controls to match real product semantics.
 
 ## Historical specs
 
-LV-101 through LV-110 are preserved in Git history and are not active instructions.
+`LV-*` specs describe completed historical Loaded Vibes generator work. Preserve them as provenance. New approved work uses `HS-*` after the product boundary decision in HS-301.
 
 ## Verification rule
 
-Do not create new test or validation systems for this UI replacement.
-
-Use existing web typecheck/build plus the narrow manual interaction/visual checks named by the active spec. Escalate to wider repository checks only when focused verification exposes a real cross-package regression.
+Do not create new test systems for this overhaul. Use only the focused typecheck/build, existing targeted tests, route smoke, interaction checks, and desktop/narrow visual inspection named by each active spec. Expand only when a focused failure demonstrates a cross-package regression.


### PR DESCRIPTION
## Summary
- reconcile the active ecosystem boundary: Codependent Coding knowledge upstream, Hipster Stack generator here, Loaded Vibes adaptive development downstream
- replace the completed LV web-refresh plan with the focused HS-301 through HS-307 roadmap
- make Product, interactive Docs, and Builder the target web surfaces
- preserve the supplied mockups as presentation authority while making shared generator semantics authoritative for behavior
- record BoldKit as locally owned presentation source and TanStack as interaction reference only
- clarify that the maximal template is a standalone application and generator-only machinery stays outside it
- constrain Codex context, edits, cleanup, and verification to minimize token use

## Validation
- compared the governance branch against current `master`
- read back the issue/spec roadmap and changed active owner files
- no runtime code changed; application test/build gates are not evidence for this governance-only change

## Notes
- does not rename the GitHub repository, runtime packages, CLI, or web implementation; those are scoped to the dependent HS issues
- historical `LV-*` specs remain provenance

Closes #135