### PR TITLE
feat(web): finish Product shell and landing

### DIFF
--- a/apps/web/app/base.css
+++ b/apps/web/app/base.css
@@ -243,13 +243,16 @@ body:has(.libraries-page, .library-detail-page)
   flex: 1;
   color: #5d747a;
 }
-.preview-window-bar button {
+.preview-window-bar .preview-open {
+  display: inline-flex;
+  align-items: center;
   padding: 7px 10px;
   border: 1px solid #26444c;
   border-radius: 4px;
   background: #102029;
   color: #809398;
   font-size: 8px;
+  text-decoration: none;
 }
 .preview-columns {
   display: grid;
@@ -395,9 +398,10 @@ body:has(.libraries-page, .library-detail-page)
   font-size: 8px;
   line-height: 1.45;
 }
-.product-entry-grid > a > b {
+.product-entry-grid .product-entry-arrow {
+  width: 16px;
+  height: 16px;
   color: var(--acid);
-  font-weight: 400;
 }
 .product-entry-grid > a:hover {
   border-color: #397483;

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -72,10 +72,6 @@ body {
 
 body:has(.product-landing) {
   background-color: var(--background);
-  background-image: url('/Digital Herencia Banner.png');
-  background-repeat: no-repeat;
-  background-position: center calc(100% - 4.5rem);
-  background-size: 100vw auto;
 }
 
 body:has(.libraries-page),
@@ -207,8 +203,14 @@ textarea {
 }
 
 .site-header .nav-cta span {
+  display: inline-flex;
   margin-left: 0.45rem;
   color: var(--signal);
+}
+
+.site-header .nav-cta span svg {
+  width: 0.8rem;
+  height: 0.8rem;
 }
 
 .site-header nav a::after {
@@ -288,7 +290,14 @@ body:has(.libraries-page, .library-detail-page, .docs-shell, .builder-page)
 }
 
 .product-shell {
-  padding: 0 1rem clamp(22rem, 58vw, 50rem);
+  padding: 0 1rem 4rem;
+}
+
+.product-landscape {
+  display: block;
+  width: 100%;
+  height: auto;
+  margin-top: 1rem;
 }
 
 .product-intro {
@@ -307,8 +316,9 @@ body:has(.libraries-page, .library-detail-page, .docs-shell, .builder-page)
 .product-copy h2 {
   max-width: 34rem;
   margin: 0;
-  font-size: clamp(2.4rem, 9vw, 4.75rem);
+  font-size: clamp(2.2rem, 6.4vw, 4.3rem);
   line-height: 0.98;
+  text-wrap: balance;
 }
 
 .product-copy > span {
@@ -380,6 +390,11 @@ body:has(.libraries-page, .library-detail-page, .docs-shell, .builder-page)
 .library-category svg,
 .library-detail-page svg {
   filter: drop-shadow(0 0 0.4rem var(--signal));
+}
+
+.product-entry-grid .product-entry-arrow {
+  width: 1rem;
+  height: 1rem;
 }
 
 .preview-columns {
@@ -651,6 +666,12 @@ body:has(.libraries-page, .library-detail-page, .docs-shell, .builder-page)
   }
 }
 
+@media (width >= 30rem) {
+  .site-header nav > a:first-child {
+    display: inline-flex;
+  }
+}
+
 @media (width >= 40rem) {
   .site-header {
     padding-inline: 1.25rem;
@@ -809,7 +830,7 @@ body:has(.libraries-page, .library-detail-page, .docs-shell, .builder-page)
 
   .product-shell {
     padding-inline: 2rem;
-    padding-bottom: clamp(32rem, 52vw, 50rem);
+    padding-bottom: 6rem;
   }
 
   .product-intro {

--- a/apps/web/components/site-header.tsx
+++ b/apps/web/components/site-header.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { ArrowRight } from 'lucide-react';
 
 export function SiteHeader() {
   return (
@@ -16,7 +17,10 @@ export function SiteHeader() {
         <Link href="/libraries">Simples</Link>
         <Link href="/docs">Docs</Link>
         <Link className="nav-cta" href="/configure">
-          Constituter <span>→</span>
+          Constituter
+          <span>
+            <ArrowRight aria-hidden="true" />
+          </span>
         </Link>
       </nav>
     </header>

--- a/apps/web/features/product/product-landing.tsx
+++ b/apps/web/features/product/product-landing.tsx
@@ -217,10 +217,7 @@ export function ProductLanding() {
                 <strong>{entry.title}</strong>
                 <small>{entry.description}</small>
               </span>
-              <ArrowRight
-                aria-hidden="true"
-                className="product-entry-arrow"
-              />
+              <ArrowRight aria-hidden="true" className="product-entry-arrow" />
             </Link>
           ))}
         </section>

--- a/apps/web/features/product/product-landing.tsx
+++ b/apps/web/features/product/product-landing.tsx
@@ -1,5 +1,8 @@
 import Image from 'next/image';
 import Link from 'next/link';
+import { ArrowRight } from 'lucide-react';
+import { buttonVariants } from '@/components/ui/button';
+import digitalHerenciaBanner from '../../../../public/Digital Herencia Banner.png';
 import loadedVibesCrown from '../../../../public/Loaded Vibes Crown.png';
 
 type IconName =
@@ -109,9 +112,9 @@ function ConstituterPreview() {
       <div className="preview-window-bar">
         <span>Constituter</span>
         <small>portable configuration</small>
-        <button type="button" disabled>
-          Export
-        </button>
+        <Link className="preview-open" href="/configure">
+          Open
+        </Link>
       </div>
       <div className="preview-columns">
         <div>
@@ -184,11 +187,19 @@ export function ProductLanding() {
               Nothing to borrow. We&apos;ve already checked.
             </span>
             <div className="product-actions">
-              <Link className="button primary" href="/configure">
-                Open the Constituter <b>→</b>
+              <Link
+                className={buttonVariants({ variant: 'default' })}
+                href="/configure"
+              >
+                Open the Constituter
+                <ArrowRight aria-hidden="true" data-icon="inline-end" />
               </Link>
-              <Link className="button" href="/libraries">
-                Survey the Simples <b>→</b>
+              <Link
+                className={buttonVariants({ variant: 'outline' })}
+                href="/libraries"
+              >
+                Survey the Simples
+                <ArrowRight aria-hidden="true" data-icon="inline-end" />
               </Link>
             </div>
           </div>
@@ -206,7 +217,10 @@ export function ProductLanding() {
                 <strong>{entry.title}</strong>
                 <small>{entry.description}</small>
               </span>
-              <b>→</b>
+              <ArrowRight
+                aria-hidden="true"
+                className="product-entry-arrow"
+              />
             </Link>
           ))}
         </section>
@@ -221,7 +235,9 @@ export function ProductLanding() {
                 <small>Select a real preset and supported capabilities.</small>
               </span>
             </article>
-            <i>→</i>
+            <i aria-hidden="true">
+              <ArrowRight />
+            </i>
             <article>
               <b>2</b>
               <span>
@@ -229,7 +245,9 @@ export function ProductLanding() {
                 <small>Resolve the actual relationships and constraints.</small>
               </span>
             </article>
-            <i>→</i>
+            <i aria-hidden="true">
+              <ArrowRight />
+            </i>
             <article>
               <b>3</b>
               <span>
@@ -268,6 +286,14 @@ export function ProductLanding() {
           <b>Fuck NeoVim, btw... · Fuck Arch, btw...</b>
         </aside>
       </div>
+
+      <Image
+        className="product-landscape"
+        src={digitalHerenciaBanner}
+        alt=""
+        aria-hidden="true"
+        sizes="100vw"
+      />
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- Completes HS-304 by rebuilding the Product landing and shared navigation against the approved mockup.

## Changes
- Uses the owned Crown and Digital Herencia Banner assets through the Next image pipeline.
- Replaces inert or text-glyph controls with real links and repository-owned shadcn Button variants.
- Preserves the Product, Simples, Docs, and Constituter route vocabulary across desktop and narrow layouts.

## QA
- corepack pnpm --dir apps/web typecheck
- corepack pnpm --dir apps/web build
- Desktop comparison at 1440x1000 against context/mockups/landing.png
- Narrow inspection at 529x941 against context/mockups/landing.png
- Direct route smoke: /, /libraries, /docs, and /configure returned HTTP 200
- Link smoke: /, /libraries, /docs, and /configure targets present in rendered Product HTML

## Risks / Notes
- Visual verification used local headless Edge after the in-app browser control bridge repeatedly timed out; rendered pages and assets were still loaded from the local Next server.

Closes #138