### PR TITLE
feat(web): rebuild Simples catalog and details

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -74,8 +74,6 @@ body:has(.product-landing) {
   background-color: var(--background);
 }
 
-body:has(.libraries-page),
-body:has(.library-detail-page),
 body:has(.builder-page) {
   background-color: var(--background);
   background-image: url('/Digital Herencia Desert BG.png');
@@ -503,10 +501,20 @@ body:has(.libraries-page, .library-detail-page, .docs-shell, .builder-page)
 }
 
 .libraries-page,
-.library-detail-page,
+.library-detail-page {
+  width: min(calc(100% - 2rem), 92rem);
+  padding-bottom: 4rem;
+}
+
 .builder-page {
   width: min(calc(100% - 2rem), 92rem);
   padding-bottom: clamp(16rem, 44vw, 34rem);
+}
+
+.simples-landscape {
+  display: block;
+  width: 100%;
+  height: auto;
 }
 
 .libraries-page {
@@ -563,6 +571,12 @@ body:has(.libraries-page, .library-detail-page, .docs-shell, .builder-page)
 
 .library-detail-sidebar {
   padding-top: 0;
+}
+
+.library-detail-actions [data-icon],
+.related-panel .related-arrow {
+  width: 1rem;
+  height: 1rem;
 }
 
 .configuration-panel-heading,
@@ -870,7 +884,11 @@ body:has(.libraries-page, .library-detail-page, .docs-shell, .builder-page)
     font-size: 1.35rem;
   }
 
-  .libraries-page,
+  .libraries-page {
+    width: min(calc(100% - 4rem), 92rem);
+    padding-bottom: 6rem;
+  }
+
   .builder-page {
     width: min(calc(100% - 4rem), 92rem);
     padding-bottom: clamp(20rem, 34vw, 34rem);

--- a/apps/web/features/libraries/libraries-catalog.tsx
+++ b/apps/web/features/libraries/libraries-catalog.tsx
@@ -1,42 +1,56 @@
+import Image from 'next/image';
 import Link from 'next/link';
 import { LibraryIcon } from '@/components/library-icon';
 import { libraries, libraryCategories } from '@/lib/libraries';
+import digitalHerenciaDesert from '../../../../public/Digital Herencia Desert BG.png';
 
 export function LibrariesCatalog() {
   return (
-    <main className="libraries-page">
-      <header className="libraries-heading">
-        <h1>Simples™</h1>
-        <p>
-          <span>An ontological survey of idiolectal semantics.</span>
-          <span>Esoteric by design.</span>
-          <span>No Ordinary Objects™</span>
-        </p>
-        <small className="simples-joke">
-          If you insist this is a collection of composite objects, the
-          mereological nihilists would like a word.
-        </small>
-      </header>
-      <section className="library-columns" aria-label="Hipster Stack Simples">
-        {libraryCategories.map((category) => (
-          <div className="library-category" key={category}>
-            <h2>{category}</h2>
-            <div>
-              {libraries
-                .filter((library) => library.category === category)
-                .map((library) => (
-                  <Link href={`/libraries/${library.slug}`} key={library.slug}>
-                    <LibraryIcon name={library.icon} />
-                    <span>
-                      <strong>{library.title}</strong>
-                      <small>{library.description}</small>
-                    </span>
-                  </Link>
-                ))}
+    <>
+      <main className="libraries-page">
+        <header className="libraries-heading">
+          <h1>Simples™</h1>
+          <p>
+            <span>An ontological survey of idiolectal semantics.</span>
+            <span>Esoteric by design.</span>
+            <span>No Ordinary Objects™</span>
+          </p>
+          <small className="simples-joke">
+            If you insist this is a collection of composite objects, the
+            mereological nihilists would like a word.
+          </small>
+        </header>
+        <section className="library-columns" aria-label="Hipster Stack Simples">
+          {libraryCategories.map((category) => (
+            <div className="library-category" key={category}>
+              <h2>{category}</h2>
+              <div>
+                {libraries
+                  .filter((library) => library.category === category)
+                  .map((library) => (
+                    <Link
+                      href={`/libraries/${library.slug}`}
+                      key={library.slug}
+                    >
+                      <LibraryIcon name={library.icon} />
+                      <span>
+                        <strong>{library.title}</strong>
+                        <small>{library.description}</small>
+                      </span>
+                    </Link>
+                  ))}
+              </div>
             </div>
-          </div>
-        ))}
-      </section>
-    </main>
+          ))}
+        </section>
+      </main>
+      <Image
+        className="simples-landscape"
+        src={digitalHerenciaDesert}
+        alt=""
+        aria-hidden="true"
+        sizes="100vw"
+      />
+    </>
   );
 }

--- a/apps/web/features/libraries/library-detail.tsx
+++ b/apps/web/features/libraries/library-detail.tsx
@@ -1,10 +1,14 @@
+import Image from 'next/image';
 import Link from 'next/link';
+import { ArrowRight, ChevronRight } from 'lucide-react';
 import { LibraryIcon } from '@/components/library-icon';
+import { buttonVariants } from '@/components/ui/button';
 import {
   getRelatedLibraries,
   getWorksWithLibraries,
   type LibraryItem,
 } from '@/lib/libraries';
+import digitalHerenciaDesert from '../../../../public/Digital Herencia Desert BG.png';
 
 function RelatedList({
   title,
@@ -24,7 +28,7 @@ function RelatedList({
               <strong>{library.title}</strong>
               <small>{library.description}</small>
             </span>
-            <b>›</b>
+            <ChevronRight aria-hidden="true" className="related-arrow" />
           </Link>
         ))}
       </div>
@@ -38,69 +42,88 @@ export function LibraryDetail({ library }: { library: LibraryItem }) {
   const isFixed = library.status === 'Fixed foundation';
 
   return (
-    <main className="library-detail-page">
-      <div className="library-detail-main">
-        <header className="library-detail-heading">
-          <p>{library.category}</p>
-          <h1>{library.title}</h1>
-          <span>{library.summary}</span>
-          <div className="library-detail-actions">
-            <Link className="button primary" href={library.primaryAction.href}>
-              {library.primaryAction.label} <b>→</b>
-            </Link>
-            <Link className="button" href="/docs">
-              Read the Docs <b>→</b>
-            </Link>
-          </div>
-        </header>
-
-        <section className="configuration-panel">
-          <div className="configuration-panel-heading">
-            <span>
-              {library.example ? 'USE IN' : 'STATUS IN'}{' '}
-              <b>hipsterstack.json</b>
-            </span>
-            <strong>{library.status}</strong>
-          </div>
-          {library.example ? (
-            <pre>{library.example}</pre>
-          ) : (
-            <div className="fixed-status">
-              <LibraryIcon name={library.icon} />
-              <span>
-                <strong>
-                  {isFixed ? 'Included / Fixed foundation' : 'Product surface'}
-                </strong>
-                <small>
-                  {isFixed
-                    ? 'No provider selector or decorative toggle. Hipster Stack owns this supported foundation.'
-                    : 'Use the canonical Hipster Stack destination for this product surface.'}
-                </small>
-              </span>
+    <>
+      <main className="library-detail-page">
+        <div className="library-detail-main">
+          <header className="library-detail-heading">
+            <p>{library.category}</p>
+            <h1>{library.title}</h1>
+            <span>{library.summary}</span>
+            <div className="library-detail-actions">
+              <Link
+                className={buttonVariants({ variant: 'default' })}
+                href={library.primaryAction.href}
+              >
+                {library.primaryAction.label}
+                <ArrowRight aria-hidden="true" data-icon="inline-end" />
+              </Link>
+              <Link
+                className={buttonVariants({ variant: 'outline' })}
+                href="/docs"
+              >
+                Read the Docs
+                <ArrowRight aria-hidden="true" data-icon="inline-end" />
+              </Link>
             </div>
-          )}
-        </section>
+          </header>
 
-        <section
-          className="library-highlights"
-          aria-label={`${library.title} highlights`}
-        >
-          {library.highlights.map((highlight, index) => (
-            <article key={highlight.title}>
-              <span>{String(index + 1).padStart(2, '0')}</span>
-              <div>
-                <strong>{highlight.title}</strong>
-                <small>{highlight.description}</small>
+          <section className="configuration-panel">
+            <div className="configuration-panel-heading">
+              <span>
+                {library.example ? 'USE IN' : 'STATUS IN'}{' '}
+                <b>hipsterstack.json</b>
+              </span>
+              <strong>{library.status}</strong>
+            </div>
+            {library.example ? (
+              <pre>{library.example}</pre>
+            ) : (
+              <div className="fixed-status">
+                <LibraryIcon name={library.icon} />
+                <span>
+                  <strong>
+                    {isFixed
+                      ? 'Included / Fixed foundation'
+                      : 'Product surface'}
+                  </strong>
+                  <small>
+                    {isFixed
+                      ? 'No provider selector or decorative toggle. Hipster Stack owns this supported foundation.'
+                      : 'Use the canonical Hipster Stack destination for this product surface.'}
+                  </small>
+                </span>
               </div>
-            </article>
-          ))}
-        </section>
-      </div>
+            )}
+          </section>
 
-      <aside className="library-detail-sidebar">
-        <RelatedList title="Related Simples" libraries={related} />
-        <RelatedList title="Works With" libraries={worksWith} />
-      </aside>
-    </main>
+          <section
+            className="library-highlights"
+            aria-label={`${library.title} highlights`}
+          >
+            {library.highlights.map((highlight, index) => (
+              <article key={highlight.title}>
+                <span>{String(index + 1).padStart(2, '0')}</span>
+                <div>
+                  <strong>{highlight.title}</strong>
+                  <small>{highlight.description}</small>
+                </div>
+              </article>
+            ))}
+          </section>
+        </div>
+
+        <aside className="library-detail-sidebar">
+          <RelatedList title="Related Simples" libraries={related} />
+          <RelatedList title="Works With" libraries={worksWith} />
+        </aside>
+      </main>
+      <Image
+        className="simples-landscape"
+        src={digitalHerenciaDesert}
+        alt=""
+        aria-hidden="true"
+        sizes="100vw"
+      />
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- Completes HS-305 by rebuilding the Simples catalog and detail presentation from the approved mockups.

## Changes
- Serves the owned Digital Herencia desert treatment through the Next image pipeline on catalog and detail pages.
- Keeps fixed/configurable status and relationships derived from the shared capability registry.
- Uses local shadcn Button variants and Lucide icons for real Docs and Constituter handoffs.

## QA
- corepack pnpm --dir apps/web typecheck
- corepack pnpm --dir apps/web build
- Route smoke: /libraries, /libraries/billing, /configure, and /docs returned HTTP 200
- Semantic smoke: required Simples copy, configurable Billing status, Constituter link, and Docs link are present
- Narrow inspection at 529x941 against context/mockups/libraries.png

## Risks / Notes
- Canonical docs and shared configuration semantics are unchanged; no route, backend, or configuration engine was added.

Closes #139